### PR TITLE
fix: Pin setup-gcloud action to latest commit

### DIFF
--- a/.github/workflows/api-prod.yaml
+++ b/.github/workflows/api-prod.yaml
@@ -51,7 +51,7 @@ jobs:
           sed -i 's/%GCP-PROD-SERVICE-ID%/${{ env.GCP_PROD_SERVICE_ID }}/g' dispatch.yaml
           sed -i 's/%GCP-STAGING-DOMAIN%/${{ env.GCP_STAGING_DOMAIN }}/g' dispatch.yaml
           sed -i 's/%GCP-STAGING-SERVICE-ID%/${{ env.GCP_STAGING_SERVICE_ID }}/g' dispatch.yaml
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@efdd40b
         with:
           version: latest
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/api-staging.yaml
+++ b/.github/workflows/api-staging.yaml
@@ -51,7 +51,7 @@ jobs:
           sed -i 's/%GCP-PROD-SERVICE-ID%/${{ env.GCP_PROD_SERVICE_ID }}/g' dispatch.yaml
           sed -i 's/%GCP-STAGING-DOMAIN%/${{ env.GCP_STAGING_DOMAIN }}/g' dispatch.yaml
           sed -i 's/%GCP-STAGING-SERVICE-ID%/${{ env.GCP_STAGING_SERVICE_ID }}/g' dispatch.yaml
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@efdd40b
         with:
           version: latest
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
# Description of change

Pins the `setup-gcloud` action to the latest commit (`efdd40b`) instead of using `master`. A specific version/tag would be ideal, however there hasn't been a new release for a few months.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code