### PR TITLE
chore(client): Bump lodash to 4.17.20

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4079,6 +4079,15 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
             "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -7481,6 +7490,12 @@
                 "schema-utils": "^2.5.0"
             }
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
+        },
         "filesize": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -10041,6 +10056,7 @@
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },
@@ -11222,9 +11238,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -18416,6 +18432,7 @@
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },
@@ -18913,6 +18930,7 @@
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },


### PR DESCRIPTION
# Description of change

Bumps `lodash` to 4.17.20 to resolve a vulnerability alert. Includes changes from #16 

## Type of change

- Chore

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code