### PR TITLE
Fix React URL with Paths cause an NGINX 404

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -14,6 +14,7 @@ RUN echo 'server {\
     location / {\
         root   /usr/src/app/build;\
         index  index.html index.htm;\
+        try_files $uri /index.html;\
     }\
   }' > /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
# Description of change

Fix issue with Docker NGINX 404 when Explorer URL on the Browser contains a path

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Tested manually

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
