### PR TITLE
fix(client): Replace node-sass with sass

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2992,12 +2992,6 @@
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
             "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
         },
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true
-        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3085,12 +3079,6 @@
             "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
         },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "dev": true
-        },
         "ansi-colors": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -3143,48 +3131,6 @@
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
-        "are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "dev": true,
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3221,12 +3167,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-        },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
         },
         "array-flatten": {
             "version": "2.1.2",
@@ -3373,12 +3313,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
-        },
-        "async-foreach": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-            "dev": true
         },
         "async-limiter": {
             "version": "1.0.1",
@@ -3956,8 +3890,16 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "optional": true
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
         },
         "bl": {
             "version": "4.0.3",
@@ -3967,15 +3909,6 @@
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
-            }
-        },
-        "block-stream": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "dev": true,
-            "requires": {
-                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -4365,24 +4298,6 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-                    "dev": true
-                }
-            }
-        },
         "caniuse-api": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -4455,7 +4370,6 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
             "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-            "optional": true,
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -4471,7 +4385,6 @@
                     "version": "5.1.1",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
                     "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-                    "optional": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
@@ -4480,7 +4393,6 @@
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
                     "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-                    "optional": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
@@ -4816,12 +4728,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
             "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "dev": true
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -5405,15 +5311,6 @@
             "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==",
             "dev": true
         },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "^1.0.1"
-            }
-        },
         "cyclist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -5613,12 +5510,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -7457,6 +7348,12 @@
                 }
             }
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
+        },
         "filesize": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -7867,18 +7764,6 @@
             "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
             "optional": true
         },
-        "fstream": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-            }
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7888,68 +7773,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-        },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dev": true,
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
-            }
-        },
-        "gaze": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-            "dev": true,
-            "requires": {
-                "globule": "^1.0.0"
-            }
         },
         "generate-function": {
             "version": "2.3.1",
@@ -7998,12 +7821,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
-        },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
         },
         "get-stream": {
             "version": "4.1.0",
@@ -8260,12 +8077,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
             "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -8860,12 +8671,6 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
-        "in-publish": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
-            "dev": true
-        },
         "indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -9011,7 +8816,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "optional": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -9114,12 +8918,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-finite": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -9297,12 +9095,6 @@
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -10971,12 +10763,6 @@
                 }
             }
         },
-        "js-base64": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
-            "dev": true
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11317,16 +11103,6 @@
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
-            }
-        },
         "lower-case": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -11391,12 +11167,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
         },
         "map-visit": {
             "version": "1.0.0",
@@ -11469,114 +11239,6 @@
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
             "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
             "dev": true
-        },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "parse-json": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.2.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                }
-            }
         },
         "merge": {
             "version": "1.2.1",
@@ -11931,7 +11593,8 @@
         "nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "optional": true
         },
         "nanoid": {
             "version": "3.1.20",
@@ -12119,34 +11782,6 @@
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
             "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
-        "node-gyp": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-            "dev": true,
-            "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-                    "dev": true
-                }
-            }
-        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12269,108 +11904,6 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
             "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw=="
         },
-        "node-sass": {
-            "version": "4.14.1",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
-            "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
-            "dev": true,
-            "requires": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^1.1.1",
-                "cross-spawn": "^3.0.0",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "in-publish": "^2.0.0",
-                "lodash": "^4.17.15",
-                "meow": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "nan": "^2.13.2",
-                "node-gyp": "^3.8.0",
-                "npmlog": "^4.0.0",
-                "request": "^2.88.0",
-                "sass-graph": "2.2.5",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "cross-spawn": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
-                    }
-                },
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                    "dev": true
-                }
-            }
-        },
-        "nopt": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-            "dev": true,
-            "requires": {
-                "abbrev": "1"
-            }
-        },
         "normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -12433,18 +11966,6 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
                 "path-key": "^2.0.0"
-            }
-        },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "dev": true,
-            "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
             }
         },
         "nth-check": {
@@ -12733,22 +12254,6 @@
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
-        },
-        "osenv": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-            "dev": true,
-            "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-            }
         },
         "p-each-series": {
             "version": "2.2.0",
@@ -14215,12 +13720,6 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
         "psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -14792,7 +14291,6 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
             "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-            "optional": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -14831,27 +14329,6 @@
             "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
             "requires": {
                 "minimatch": "3.0.4"
-            }
-        },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
-            "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
-            },
-            "dependencies": {
-                "indent-string": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                    "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-                    "dev": true,
-                    "requires": {
-                        "repeating": "^2.0.0"
-                    }
-                }
             }
         },
         "regenerate": {
@@ -15004,15 +14481,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "^1.0.0"
-            }
         },
         "request": {
             "version": "2.88.2",
@@ -15534,16 +15002,13 @@
             "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
             "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
         },
-        "sass-graph": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
-            "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+        "sass": {
+            "version": "1.32.6",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
+            "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "lodash": "^4.0.0",
-                "scss-tokenizer": "^0.2.3",
-                "yargs": "^13.3.2"
+                "chokidar": ">=2.0.0 <4.0.0"
             }
         },
         "sass-lint": {
@@ -16082,27 +15547,6 @@
                 "@types/json-schema": "^7.0.5",
                 "ajv": "^6.12.4",
                 "ajv-keywords": "^3.5.2"
-            }
-        },
-        "scss-tokenizer": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-            "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-            "dev": true,
-            "requires": {
-                "js-base64": "^2.1.8",
-                "source-map": "^0.4.2"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "dev": true,
-                    "requires": {
-                        "amdefine": ">=0.0.4"
-                    }
-                }
             }
         },
         "select-hose": {
@@ -16781,47 +16225,6 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         },
-        "stdout-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-            "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "stealthy-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -17076,15 +16479,6 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
-        "strip-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "^4.0.1"
-            }
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -17216,17 +16610,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
-        },
-        "tar": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-            "dev": true,
-            "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.12",
-                "inherits": "2"
-            }
         },
         "temp-dir": {
             "version": "1.0.0",
@@ -17592,21 +16975,6 @@
             "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
             "requires": {
                 "punycode": "^2.1.1"
-            }
-        },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-            "dev": true
-        },
-        "true-case-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2"
             }
         },
         "tryer": {
@@ -18246,6 +17614,7 @@
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },
@@ -18786,6 +18155,7 @@
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },
@@ -19075,48 +18445,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-        },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^1.0.2 || 2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
         },
         "word-wrap": {
             "version": "1.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -65,8 +65,8 @@
         "eslint-plugin-jsdoc": "^31.6.0",
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-unicorn": "^27.0.0",
-        "node-sass": "^4.14.1",
         "npm-run-all": "^4.1.5",
+        "sass": "^1.32.6",
         "sass-lint": "^1.13.1",
         "typescript": "^4.1.3"
     }


### PR DESCRIPTION
# Description of change

`node-sass` is no longer maintained and is causing security alerts:

> If you’re a user of Node Sass, migrating to Dart Sass is straightforward: just replace node-sass in your package.json file with sass. Both packages expose the same JavaScript API.

https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code