### PR TITLE
Feat: adapt pages to receive new data

### DIFF
--- a/client/src/app/components/chrysalis/IndexationPayload.tsx
+++ b/client/src/app/components/chrysalis/IndexationPayload.tsx
@@ -57,7 +57,7 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
         return (
             <div className="indexation-payload">
                 <div className="card--header">
-                    <h2>{this.props.advancedMode ? "Indexation Payload" : "Data"}</h2>
+                    <h2>Indexation Payload</h2>
                 </div>
                 <div className="card--content">
                     <div className="card--label row middle">
@@ -80,28 +80,25 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
                             {this.state.utf8Index}
                         </Link>
                     </div>
-                    {this.props.advancedMode && (
-                        <React.Fragment>
-                            <div className="card--label row middle">
-                                <span className="margin-r-t">Index Hex [{this.state.indexLengthBytes}]</span>
-                                <MessageButton
-                                    onClick={() => ClipboardHelper.copy(
-                                        this.state.hexIndex.replace(/ /g, "")
-                                    )}
-                                    buttonType="copy"
-                                    labelPosition="right"
-                                />
-                            </div>
-                            <div className="card--value card--value-textarea card--value-textarea__hex card--value-textarea__fit">
-                                {this.state.hexIndex}
-                            </div>
+                    <div className="card--label row middle">
+                        <span className="margin-r-t">Index Hex [{this.state.indexLengthBytes}]</span>
+                        <MessageButton
+                            onClick={() => ClipboardHelper.copy(
+                                this.state.hexIndex.replace(/ /g, "")
+                            )}
+                            buttonType="copy"
+                            labelPosition="right"
+                        />
+                    </div>
+                    <div className="card--value card--value-textarea card--value-textarea__hex card--value-textarea__fit">
+                        {this.state.hexIndex}
+                    </div>
 
-                        </React.Fragment>
-                    )}
+
                     {!this.state.jsonData && this.state.utf8Data && (
                         <React.Fragment>
                             <div className="card--label row middle">
-                                <span className="margin-r-t">{this.props.advancedMode ? `Data UTF8 [${this.state.dataLengthBytes}]` : "Content"}</span>
+                                <span className="margin-r-t">{this.props.advancedMode ? `Data UTF8 [${this.state.dataLengthBytes}]` : "Data"}</span>
                                 <MessageButton
                                     onClick={() => ClipboardHelper.copy(
                                         this.state.utf8Data
@@ -134,7 +131,7 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
                             </div>
                         </React.Fragment>
                     )}
-                    {this.props.advancedMode && this.state.hexData && (
+                    {this.state.hexData && (
                         <React.Fragment>
                             <div className="card--label row middle">
                                 <span className="margin-r-t">Data Hex [{this.state.dataLengthBytes}]</span>

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -100,8 +100,6 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
             }, async () => {
                 await this.updateMessageDetails();
             });
-            console.log(result?.message?.payload?.type);
-            console.log(result?.message);
         } else {
             this.props.history.replace(`/${this.props.match.params.network
                 }/search/${this.props.match.params.messageId}`);


### PR DESCRIPTION
# Description of change

This PR is intended to leave a skeleton of the pages that render messages ready to have all the new data. This skeleton will not have a defined design but it will serve as a base to start the layout of the components.
The following sections have been modified:

- General (modified):

> - Payload Type (added)
> - Parent messages (moved to the Message Tree section)
> - Confirmed/Pending tag (added)
![image](https://user-images.githubusercontent.com/36295331/126804269-83ef057b-93b6-4113-8405-0bc6d89c8900.png)

- Indexation Payload (modified)

> - Hexadecimal format visible in user mode as well.
> -  Childs (removed and data moved to Message Tree)
![image](https://user-images.githubusercontent.com/36295331/126804331-d4389846-a912-46c4-94f7-8b7b6d469b12.png)

-  Message Tree (added):

> - Parents
> - Childs
> - Own id
![image](https://user-images.githubusercontent.com/36295331/126804399-aeb6ddeb-00b0-4320-8e25-64c102e6074f.png)

- Side Panel (removed)
![image](https://user-images.githubusercontent.com/36295331/126805049-6c0fcf2b-3db1-4d27-8db3-09f818bb014d.png)


- Transaction Payload (pending)
- Milestones Payload (pending)


