### PR TITLE
fix(api): Support compiling zeromq in Docker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:14-alpine3.13
-RUN apk --no-cache add git
+FROM node:14-alpine3.13 AS build
+RUN apk --no-cache add git curl python3 build-base cmake
 
 # Working DIR
 WORKDIR /usr/src/app
@@ -14,8 +14,16 @@ RUN npm install -g npm
 ARG CONFIG_ID
 RUN echo "CONFIG_ID=$CONFIG_ID"
 
-# Install all the packages for the workspaces
-RUN npm install --only=prod
+# Install all packages necessary for compilation, then remove the devDependencies
+RUN npm install && npm run build-config && npm run build-compile && npm prune --production
+
+FROM node:14-alpine3.13
+
+WORKDIR /usr/src/app
+
+RUN apk --no-cache add git
+
+COPY --from=build /usr/src/app .
 
 EXPOSE 4000
 


### PR DESCRIPTION
# Description of change

`zeromq` requires native code compilation, but we can't guarantee the availability of prebuilt binaries (e.g. https://github.com/iotaledger/one-click-tangle/issues/45). This PR adds the necessary dependencies to build `zeromq` if necessary. Since including these dependencies increases the image size considerably, we can use a multi-stage build to copy the compiled JS and production dependencies to a fresh container.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested building the Docker image locally

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas