### PR TITLE
Fix message tree jump

### DIFF
--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -78,7 +78,17 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
         }
     }
 
-    public componentDidUpdate(prevProps: MessageTreeProps): void {
+    public scrollToMessageTree() {
+        const top = document?.getElementById("message-tree")?.offsetTop ?? 0;
+        const OFFSET = 200;
+        window.scrollTo({
+            left: 0,
+            top: top - OFFSET,
+            behavior: "smooth"
+        });
+    }
+
+    public componentDidUpdate(prevProps: MessageTreeProps, prevState: MessageTreeState): void {
         if (prevProps !== this.props) {
             this.setState(
                 {
@@ -89,18 +99,6 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                     this.loadItemsUI();
                     this.setState({ isBusy: false });
                 });
-
-            if (this.props.parentsIds !== prevProps.parentsIds || this.props.childrenIds !== prevProps.childrenIds) {
-                // ------- Scroll to messages tree section -------
-                const top = document?.getElementById("message-tree")?.offsetTop ?? 0;
-                const OFFSET = 200;
-                window.scrollTo({
-                    left: 0,
-                    top: top - OFFSET,
-                    behavior: "smooth"
-                });
-                // -----------------------------------------------
-            }
         }
     }
 
@@ -157,6 +155,7 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                             className={item.type}
                             key={item.id}
                             onClick={() => {
+                                this.scrollToMessageTree();
                                 this.setState({ currentMessage: item.id, isBusy: true }, () => {
                                     this.props.onSelected(item.id, true);
                                 });


### PR DESCRIPTION
# Description of change

Fix tx page unnecessary auto scroll to bottom when the message tree of a selected message changes. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
