### PR TITLE
Add inspiration credit

### DIFF
--- a/client/src/app/App.scss
+++ b/client/src/app/App.scss
@@ -34,17 +34,21 @@
 
   .copyright {
     display: flex;
+    height: 52px;
+    letter-spacing: 0.1em;
     justify-content: center;
-    margin: 20px 0;
+    align-items: center;
+    background-color: var(--header-identity);
 
     .copyright-inner {
       max-width: $desktop-width;
-      color: var(--body-color);
+      font-weight: 600;
+      color: $gray-6;
       font-family: $metropolis;
-
       @include font-size(12px);
 
       a {
+        text-decoration: none;
         color: $main-green-highlight;
       }
     }

--- a/client/src/app/App.scss
+++ b/client/src/app/App.scss
@@ -32,5 +32,23 @@
     }
   }
 
+  .copyright {
+    display: flex;
+    justify-content: center;
+    margin: 20px 0;
+
+    .copyright-inner {
+      max-width: $desktop-width;
+      color: var(--body-color);
+      font-family: $metropolis;
+
+      @include font-size(12px);
+
+      a {
+        color: $main-green-highlight;
+      }
+    }
+  }
+
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }

--- a/client/src/app/App.scss
+++ b/client/src/app/App.scss
@@ -47,6 +47,14 @@
       font-family: $metropolis;
       @include font-size(12px);
 
+      @include phone-down {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          width: 300px;
+          line-height: 20px;
+      }
+        
       a {
         text-decoration: none;
         color: $main-green-highlight;

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -278,7 +278,7 @@ class App extends Component<RouteComponentProps<AppRouteProps> & { config: IConf
                                     )}
                                 <div className="copyright">
                                     <div className="copyright-inner">
-                                        This explorer implementation is heavily inspired
+                                        This explorer implementation is inspired
                                         by <a href="https://thetangle.org">thetangle.org</a>.
                                     </div>
                                 </div>

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -278,8 +278,7 @@ class App extends Component<RouteComponentProps<AppRouteProps> & { config: IConf
                                     )}
                                 <div className="copyright">
                                     <div className="copyright-inner">
-                                        This explorer implementation is inspired
-                                        by <a href="https://thetangle.org">thetangle.org</a>.
+                                        This explorer implementation is inspired by <span><a href="https://thetangle.org">thetangle.org</a>.</span>
                                     </div>
                                 </div>
                             </React.Fragment>

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -276,6 +276,12 @@ class App extends Component<RouteComponentProps<AppRouteProps> & { config: IConf
                                             />
                                         </Switch>
                                     )}
+                                <div className="copyright">
+                                    <div className="copyright-inner">
+                                        This explorer implementation is heavily inspired
+                                        by <a href="https://thetangle.org">thetangle.org</a>.
+                                    </div>
+                                </div>
                             </React.Fragment>
                         )
                         : (


### PR DESCRIPTION
The UI and some features of your v2 explorer is highly inspired from [thetangle.org](https://thetangle.org/) but it's never mentioned.
Feature requests also directly ask to copy thetangle.org (eg. #148, #75, #46, #81).
Similarly to [what the Hornet team did](https://github.com/gohornet/hornet/blob/b09279f3ffa3dc28432e7439c1a606c9ceabf8b5/plugins/spa/frontend/src/app/components/Explorer.tsx#L33) for their built-in explorer, this PR adds the mention of thetangle.org in the footer.

![just-blue-links-on-white-background](https://user-images.githubusercontent.com/3019820/153753247-b8ac4abd-af10-47ca-a410-0d1ae4204e92.png)

