### PR TITLE
Fix: duplicated history tsx

### DIFF
--- a/client/src/app/components/chrysalis/Transaction.tsx
+++ b/client/src/app/components/chrysalis/Transaction.tsx
@@ -43,6 +43,7 @@ class Transaction extends Component<TransactionProps, TransactionState> {
                                 <MessageTangleState
                                     network={this.props.network}
                                     status={this.props.messageTangleStatus}
+                                    hasConflicts={this.props.hasConflicts}
                                 />
                             )
                             : <Spinner />}

--- a/client/src/app/components/chrysalis/TransactionProps.tsx
+++ b/client/src/app/components/chrysalis/TransactionProps.tsx
@@ -34,4 +34,8 @@ export interface TransactionProps {
      * True if the transaction is rendered like a table
      */
     tableFormat?: boolean;
+    /**
+     * The message has conflicts.
+     */
+    hasConflicts?: boolean;
 }

--- a/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
+++ b/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
@@ -85,6 +85,10 @@ export interface ITransaction {
          */
         amount?: number;
     };
+    /**
+     * Is transaction included in ledger.
+     */
+    ledgerInclusionState: string;
 }
 
 export interface ITransactionsDetailsResponse extends IResponse {

--- a/client/src/services/tangleCacheService.ts
+++ b/client/src/services/tangleCacheService.ts
@@ -842,6 +842,7 @@ export class TangleCacheService {
         if (!this._chrysalisSearchCache[request.network][request.address]?.data?.transactionHistory || skipCache) {
             const apiClient = ServiceFactory.get<ApiClient>("api-client");
             const response = await apiClient.transactionsDetails(request);
+
             if (response?.transactionHistory?.transactions) {
                 const cachedTransaction = this._chrysalisSearchCache[request.network][request.address]
                                                 ?.data?.transactionHistory?.transactionHistory.transactions ?? [];
@@ -855,8 +856,8 @@ export class TangleCacheService {
                     cached: Date.now()
                 };
             }
-            // Fetch next page if returned page size equals requested page size
-            if (response?.transactionHistory?.transactions?.length === request.query?.page_size) {
+
+            if (response?.transactionHistory?.state) {
                 return this.transactionsDetails({
                     network: request.network,
                     address: request.address,


### PR DESCRIPTION
# Description of change

This PR aims to fix two issues on Address page:

1.  #97
2. #166

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Test for #97 issue: Navigate to any address page with conflicting transactions ex. `/mainnet/addr/iota1qz2xs449nm04al9pyxvfl9mgaj359fj06y3awetg7c6vjd0jjm39cyuku8a`

Test for #166 issue: Navigate to any address page with more than 10 history transactions and go trough history transactions using pagination

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
