### PR TITLE
Fix: identity doc display

### DIFF
--- a/client/src/app/routes/IdentityResolver.tsx
+++ b/client/src/app/routes/IdentityResolver.tsx
@@ -288,7 +288,7 @@ class IdentityResolver extends AsyncComponent<
                                                             </React.Fragment>
                                                         )}
 
-                                                        {this.state.resolvedIdentity && (
+                                                        {this.state.resolvedIdentity?.document && (
                                                             <div className="w100">
                                                                 <div className="identity-json-header">
                                                                     <div>
@@ -331,7 +331,7 @@ class IdentityResolver extends AsyncComponent<
                                                                 >
                                                                     <JsonViewer
                                                                         json={JSON.stringify(
-                                                                            this.state.resolvedIdentity.document,
+                                                                            this.state.resolvedIdentity.document.doc,
                                                                             null,
                                                                             4
                                                                         )}


### PR DESCRIPTION
# Description of change

Restored changes lost in a recent merge of `dev`. This fixes the display of the document in the identity resolver to only display the content of `doc`,

Seems to have been caused here: https://github.com/iotaledger/explorer/blob/61edccc3785c9c6d2dc90604a5b0edac62aeca94/client/src/app/routes/IdentityResolver.tsx

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
