### PR TITLE
Feat: Support pausing/resuming the visualiser

### DIFF
--- a/client/src/app/routes/Visualizer.scss
+++ b/client/src/app/routes/Visualizer.scss
@@ -46,6 +46,18 @@
       font-family: $metropolis;
       word-break: break-all;
     }
+
+    .action-panel-container {
+        display: flex;
+        position: absolute;
+        z-index: 2;
+        top: 20px;
+        right: 20px;
+
+        .pause-button {
+            padding: 6px;
+        }
+    }
   }
 
   .filter {

--- a/client/src/app/routes/Visualizer.tsx
+++ b/client/src/app/routes/Visualizer.tsx
@@ -3,6 +3,8 @@ import { Converter } from "@iota/util.js";
 import React, { ReactNode } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import Viva from "vivagraphjs";
+import { ReactComponent as PauseIcon } from "../../assets/pause.svg";
+import { ReactComponent as PlayIcon } from "../../assets/play.svg";
 import { buildCircleNodeShader } from "../../helpers/circleNodeShader";
 import { RouteBuilder } from "../../helpers/routeBuilder";
 import { IFeedItemMetadata } from "../../models/api/IFeedItemMetadata";
@@ -152,7 +154,8 @@ class Visualizer extends Feeds<RouteComponentProps<VisualizerRouteProps> & Visua
             currencies: [],
             itemCount: 0,
             selectedFeedItem: undefined,
-            filter: ""
+            filter: "",
+            isActive: true
         };
     }
 
@@ -400,6 +403,17 @@ class Visualizer extends Feeds<RouteComponentProps<VisualizerRouteProps> & Visua
                             }}
                             ref={r => this.setupGraph(r)}
                         />
+                        <div className="action-panel-container">
+                            <div className="card">
+                                <button
+                                    className="pause-button"
+                                    type="button"
+                                    onClick={() => this.toggleActivity()}
+                                >
+                                    {this.state.isActive ? <PauseIcon /> : <PlayIcon />}
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div className="row middle margin-t-s">
@@ -827,6 +841,21 @@ class Visualizer extends Feeds<RouteComponentProps<VisualizerRouteProps> & Visua
                 y: this._graphElement.clientHeight / 2
             });
         }
+    }
+
+    /**
+     * The pause button was clicked
+     */
+    private toggleActivity(): void {
+        if (this._renderer) {
+            if (this.state.isActive) {
+                this._renderer.pause();
+            } else {
+                this._renderer.resume();
+            }
+        }
+
+        this.setState({ isActive: !this.state.isActive });
     }
 
     /**

--- a/client/src/app/routes/VisualizerState.ts
+++ b/client/src/app/routes/VisualizerState.ts
@@ -17,4 +17,9 @@ export interface VisualizerState extends FeedsState {
      * Filter on a specific tag/address/hash/bundle.
      */
     filter: string;
+
+    /**
+     * Is Visualizer active flag.
+     */
+    isActive: boolean;
 }


### PR DESCRIPTION
# Description of change

Added a pause button to visualiser and functionality to pause() and resume() the renderer on button toggle.

Closes: https://github.com/iotaledger/explorer/issues/181

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Clicking the button pauses/resumes visualisation

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code

PR for https://github.com/iotaledger/explorer/issues/194