### PR TITLE
Fix(css): Remove top padding on feeds wrapper

### DIFF
--- a/client/src/app/routes/Landing.scss
+++ b/client/src/app/routes/Landing.scss
@@ -566,6 +566,6 @@
   }
 
   .feeds-wrapper {
-    padding: 44px $inner-padding;
+    padding: 0px $inner-padding 44px;
   }
 }


### PR DESCRIPTION
# Description of change

Removed top padding of .feeds-wrapper

## Type of change

Bug fix (css)

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code

PR for https://github.com/iotaledger/explorer/issues/187
