### PR TITLE
Fix: Add adjustments for filters header and toggle filters button

### DIFF
--- a/client/src/app/routes/Landing.scss
+++ b/client/src/app/routes/Landing.scss
@@ -225,8 +225,25 @@
               display: flex;
               position: relative;
 
-              button:first-child {
+              .pause-button {
                 margin-right: 16px;
+              }
+
+              .filters-button-wrapper {
+                  position: relative;
+                  .active-filters-counter {
+                      font-family: $inter;
+                      position: absolute;
+                      top: 2px;
+                      right: 2px;
+                      width: 12px;
+                      font-size: 10px;
+                      background: #14cabf;
+                      text-align: center;
+                      color: #ffffff;
+                      border-radius: 8px;
+                      font-weight: 700;
+                  }
               }
             }
 
@@ -272,7 +289,7 @@
 
                 .filter-header {
                   margin-bottom: 8px;
-                  padding: 8px;
+                  padding: 8px 10px;
                   border-bottom: 1px solid var(--input-border-color);
                   color: $gray-7;
                   font-family: $inter;
@@ -289,6 +306,11 @@
                     color: var(--header-color);
                     font-family: $inter;
                     font-weight: 400;
+                    &.done-button {
+                        background: #14cabf;
+                        color: #ffffff;
+                        border: none;
+                    }
                   }
                 }
 

--- a/client/src/app/routes/Landing.scss
+++ b/client/src/app/routes/Landing.scss
@@ -225,22 +225,18 @@
               display: flex;
               position: relative;
 
-              .pause-button {
-                margin-right: 16px;
-              }
-
               .filters-button-wrapper {
                   position: relative;
-                  .active-filters-counter {
+                  .filters-button-wrapper__counter {
                       font-family: $inter;
                       position: absolute;
                       top: 2px;
                       right: 2px;
                       width: 12px;
                       font-size: 10px;
-                      background: #14cabf;
+                      background: var(--mint-green-bg);
                       text-align: center;
-                      color: #ffffff;
+                      color: $white;
                       border-radius: 8px;
                       font-weight: 700;
                   }
@@ -307,8 +303,8 @@
                     font-family: $inter;
                     font-weight: 400;
                     &.done-button {
-                        background: #14cabf;
-                        color: #ffffff;
+                        background: var(--mint-green-bg);
+                        color: $white;
                         border: none;
                     }
                   }

--- a/client/src/app/routes/Landing.tsx
+++ b/client/src/app/routes/Landing.tsx
@@ -182,7 +182,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                         <h2>Latest messages</h2>
                                         <div className="feed--actions">
                                             <button
-                                                className="button--unstyled pause-button"
+                                                className="button--unstyled"
                                                 type="button"
                                                 onClick={() => {
                                                     this.setState({
@@ -203,7 +203,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                                 >
                                                     <FilterIcon />
                                                 </button>
-                                                <div className="active-filters-counter">
+                                                <div className="filters-button-wrapper__counter">
                                                     {this.state.valuesFilter.filter(f => f.isEnabled).length}
                                                 </div>
                                             </div>

--- a/client/src/app/routes/Landing.tsx
+++ b/client/src/app/routes/Landing.tsx
@@ -182,7 +182,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                         <h2>Latest messages</h2>
                                         <div className="feed--actions">
                                             <button
-                                                className="button--unstyled"
+                                                className="button--unstyled pause-button"
                                                 type="button"
                                                 onClick={() => {
                                                     this.setState({
@@ -193,26 +193,38 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                             >
                                                 {this.state.isFeedPaused ? <PlayIcon /> : <PauseIcon />}
                                             </button>
-                                            <button
-                                                type="button"
-                                                className="button--unstyled"
-                                                onClick={() => {
-                                                    this.setState({ isFilterExpanded: !this.state.isFilterExpanded });
-                                                }}
-                                            >
-                                                <FilterIcon />
-                                            </button>
+                                            <div className="filters-button-wrapper">
+                                                <button
+                                                    type="button"
+                                                    className="button--unstyled toggle-filters-button"
+                                                    onClick={() => {
+                                                        this.setState({ isFilterExpanded: !this.state.isFilterExpanded });
+                                                    }}
+                                                >
+                                                    <FilterIcon />
+                                                </button>
+                                                <div className="active-filters-counter">
+                                                    {this.state.valuesFilter.filter(f => f.isEnabled).length}
+                                                </div>
+                                            </div>
                                             {this.state.isFilterExpanded && (
                                                 <div className="filter-wrapper">
                                                     <div className="filter">
                                                         <div className="filter-header row space-between middle">
-                                                            <span>Payload Filter</span>
                                                             <button
                                                                 className="button--unstyled"
                                                                 type="button"
                                                                 onClick={() => this.resetFilters()}
                                                             >
                                                                 Reset
+                                                            </button>
+                                                            <span>Payload Filter</span>
+                                                            <button 
+                                                                className="done-button"
+                                                                type="button"
+                                                                onClick={() => this.setState({ isFilterExpanded: false })}
+                                                            >
+                                                                Done
                                                             </button>
                                                         </div>
 

--- a/client/src/scss/themes.scss
+++ b/client/src/scss/themes.scss
@@ -38,6 +38,7 @@
   --search-svg: #{$gray-6};
   --identity-added: #e6ffed;
   --identity-removed: #ffeef0;
+  --mint-green-bg: #{$mint-green-6};
 
   body.darkmode {
     --body-background: #091326;
@@ -76,5 +77,6 @@
     --search-svg: #{$gray-5};
     --identity-added: rgba(20, 202, 191, 0.08);
     --identity-removed: rgba(118, 45, 52, 0.49);
+    --mint-green-bg: #{$mint-green-7};
   }
 }


### PR DESCRIPTION
# Description of change

Performed adjustments as described in the task:
- Added Done button in filters header which closes the modal
- Reordered entries in header
- Aligned header with checkboxes below
- Added an indicator to the filters toggle button showing counter for enabled filters

Fixes https://github.com/iotaledger/explorer/issues/191

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Check look is as requested in proposed design https://www.figma.com/file/j4RLa61iZ18VXwiabeyu9k/IOTA-Explorer-UI?node-id=1706%3A28366
- Check it looks good on both themes
- Close filters button works

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
