### PR TITLE
Fix: Reduce min-height of header banner

### DIFF
--- a/client/src/app/routes/Landing.scss
+++ b/client/src/app/routes/Landing.scss
@@ -24,14 +24,14 @@
         flex-wrap: wrap;
         align-items: center;
         justify-content: space-between;
-        min-height: 446px;
+        min-height: 280px;
         padding: 50px 0;
 
         @include desktop-down {
           flex-direction: column;
           align-items: inherit;
           justify-content: space-between;
-          padding-top: 133px;
+          padding-top: 96px;
           padding-bottom: 0;
         }
 
@@ -533,7 +533,6 @@
     }
 
     &::before {
-      top: 75px;
       right: 50%;
       transform: translateX(300%);
       background: var(--bubble-2);
@@ -549,7 +548,7 @@
     }
 
     &::after {
-      bottom: 25px;
+      bottom: -25px;
       left: 50%;
       transform: translateX(-100%);
       background: var(--bubble-1);


### PR DESCRIPTION
# Description of change

- Reduced height of header banner to 280px
- Adjusted position of sphere images to be similarly positioned as before
- Reduced top padding of header banner on smaller desktops

Fixes https://github.com/iotaledger/explorer/issues/186

## Type of change

Bug fix (css)

## How the change has been tested

- Visual check

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
