### PR TITLE
Feat: Re-implement currency drop-down selector

### DIFF
--- a/api/src/clients/fixerClient.ts
+++ b/api/src/clients/fixerClient.ts
@@ -1,4 +1,5 @@
 import { ILatestResponse } from "../models/clients/fixer/ILatestResponse";
+import { ISymbolsResponse } from "../models/clients/fixer/ISymbolsResponse";
 import { FetchHelper } from "../utils/fetchHelper";
 
 /**
@@ -40,6 +41,24 @@ export class FixerClient {
             );
         } catch {
         }
+
+        return response;
+    }
+
+    /**
+     * Get the latest api currency names.
+     * @returns The currency names.
+     */
+    public async symbols(): Promise<ISymbolsResponse> {
+        let response: ISymbolsResponse;
+
+        try {
+            response = await FetchHelper.json<unknown, ISymbolsResponse>(
+                this._endpoint,
+                `symbols?access_key=${this._apiKey}`,
+                "get"
+            );
+        } catch { }
 
         return response;
     }

--- a/api/src/initServices.ts
+++ b/api/src/initServices.ts
@@ -122,9 +122,12 @@ export async function initServices(config: IConfiguration) {
         }
     }
 
+    const currencyService = new CurrencyService(config);
+    let log = await currencyService.updateCurrencyNames();
+    console.log(log);
+
     const update = async () => {
-        const currencyService = new CurrencyService(config);
-        const log = await currencyService.update();
+        log = await currencyService.update();
         console.log(log);
     };
 

--- a/api/src/models/api/ICurrencyNamesResponse.ts
+++ b/api/src/models/api/ICurrencyNamesResponse.ts
@@ -1,0 +1,9 @@
+import { IResponse } from "./IResponse";
+import { ISignedResponse } from "./ISignedResponse";
+
+export interface ICurrencyNamesResponse extends IResponse, ISignedResponse {
+    /**
+     * The currency acronym to name map.
+     */
+    currencyNames?: { [id: string]: string };
+}

--- a/api/src/models/clients/fixer/ISymbolsResponse.ts
+++ b/api/src/models/clients/fixer/ISymbolsResponse.ts
@@ -1,0 +1,10 @@
+export interface ISymbolsResponse {
+    /**
+     * Was the request a success.
+     */
+    success: boolean;
+    /**
+     * The currency names.
+     */
+    symbols: { symbol: string };
+}

--- a/api/src/models/db/ICurrencyState.ts
+++ b/api/src/models/db/ICurrencyState.ts
@@ -33,4 +33,9 @@ export interface ICurrencyState {
      * Exchange rates based on EUR.
      */
     exchangeRatesEUR: { [id: string]: number };
+
+    /**
+     * Full currency names
+     */
+    currencyNames: { [id: string]: string };
 }

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -18,6 +18,7 @@ export const routes: IRoute[] = [
     { path: "/init", method: "get", func: "init" },
     { path: "/networks", method: "get", folder: "networks", func: "get" },
     { path: "/currencies", method: "get", folder: "currency", func: "get", sign: true },
+    { path: "/currency/names", method: "get", folder: "currency/names", func: "get", sign: true },
     { path: "/transactions/:network/:hash", method: "get", folder: "og/transactions", func: "get" },
     { path: "/transactions/:network/:hash/action/:action", method: "get", folder: "og/transactions", func: "action" },
     { path: "/trytes/:network", method: "post", folder: "og/trytes", func: "post" },

--- a/api/src/routes/currency/names/get.ts
+++ b/api/src/routes/currency/names/get.ts
@@ -1,0 +1,26 @@
+import { ServiceFactory } from "../../../factories/serviceFactory";
+import { ICurrencyNamesResponse } from "../../../models/api/ICurrencyNamesResponse";
+import { ICurrencyState } from "../../../models/db/ICurrencyState";
+import { IStorageService } from "../../../models/services/IStorageService";
+
+/**
+ * Get the map of currency acronym to currency name.
+ * @returns The response.
+ */
+export async function get(): Promise<ICurrencyNamesResponse> {
+    const currencyStorageService = ServiceFactory.get<IStorageService<ICurrencyState>>("currency-storage");
+
+    if (currencyStorageService) {
+        const currency = await currencyStorageService.get("default");
+
+        if (!currency) {
+            throw new Error("Unable to get currency data.");
+        }
+
+        return {
+            currencyNames: currency.currencyNames
+        };
+    }
+
+    throw new Error("Currency storage not configured");
+}

--- a/api/src/routes/init.ts
+++ b/api/src/routes/init.ts
@@ -26,9 +26,9 @@ export async function init(config: IConfiguration): Promise<string[]> {
             log += await marketStorageService.create();
         }
 
-        const stateStorageService = ServiceFactory.get<IStorageService<ICurrencyState>>("currency-storage");
-        if (stateStorageService) {
-            log += await stateStorageService.create();
+        const currencyStorageService = ServiceFactory.get<IStorageService<ICurrencyState>>("currency-storage");
+        if (currencyStorageService) {
+            log += await currencyStorageService.create();
         }
 
         const milestoneStorageService = ServiceFactory.get<IStorageService<IMilestoneStore>>("milestone-storage");
@@ -39,6 +39,7 @@ export async function init(config: IConfiguration): Promise<string[]> {
         const currencyService = new CurrencyService(config);
         if (currencyService) {
             log += await currencyService.update(true);
+            log += await currencyService.updateCurrencyNames();
         }
     } catch (err) {
         log += `Failed\n${err.toString()}\n`;

--- a/client/src/app/components/FiatSelector.scss
+++ b/client/src/app/components/FiatSelector.scss
@@ -1,0 +1,107 @@
+@import "./../../scss/fonts";
+@import "./../../scss/mixins";
+@import "./../../scss/media-queries";
+@import "./../../scss/variables";
+@import "./../../scss/themes";
+
+.fiat-selector {
+    position: relative;
+    margin-left: 16px;
+    font-family: $inter;
+
+    .fiat-selector__button {
+        @include font-size(14px);
+
+        display: flex;
+        align-items: center;
+        height: 40px;
+        margin: 0;
+        padding: 0 48px 0 20px;
+        transition: border-color 0.2s ease;
+        border: 1px solid var(--input-border-color);
+        border-radius: 8px;
+        outline: none;
+        background-color: transparent;
+        color: var(--body-color);
+        appearance: none;
+        box-shadow: none;
+
+        &:focus {
+          border-color: var(--input-focus-border-color);
+        }
+
+        &:-ms-expand {
+          display: none;
+        }
+
+        &:-moz-focusring {
+          color: transparent;
+          text-shadow: 0 0 0 $gray-10;
+
+          * {
+            color: $gray-10;
+            text-shadow: none;
+          }
+        }
+    }
+
+    .fiat-selector__entries {
+        z-index: 5;
+        position: absolute;
+        width: 356px;
+        max-height: 500px;
+
+        @include font-size(14px);
+        border: 1px solid var(--input-border-color);
+        border-radius: 6px;
+        background-color: var(--body-background);
+        color: var(--body-color);
+        overflow: auto;
+
+        @include desktop-down {
+            right: 0;
+        }
+
+        @include phone-down {
+            position: fixed;
+            width: 100%;
+        }
+
+        .group-header {
+            color: $gray-5;
+            font-weight: 500;
+            padding: 24px 20px 14px;
+            cursor: default;
+        }
+
+        .fiat-selector__currency {
+            display: flex;
+            margin: 0 20px;
+            padding: 10px 0;
+            border-bottom: 1px solid var(--input-border-color);
+            cursor: pointer;
+
+            .acronym {
+                width: 38px;
+                margin-right: 8px;
+                color: $gray-11;
+                font-weight: 600;
+                letter-spacing: 0.5px;
+            }
+
+            .full-name {
+                color: $gray-7;
+            }
+        }
+    }
+
+    img {
+        position: absolute;
+        z-index: 2;
+        top: 43%;
+        right: 18px;
+        color: $gray;
+        pointer-events: none;
+    }
+  
+}

--- a/client/src/app/components/FiatSelector.tsx
+++ b/client/src/app/components/FiatSelector.tsx
@@ -1,31 +1,108 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, RefObject } from "react";
 import chevronDownGray from "../../assets/chevron-down-gray.svg";
 import Currency from "./Currency";
-import "./CurrencyButton.scss";
-import { CurrencyState } from "./CurrencyState";
+import { FiatSelectorState } from "./FiatSelectorState";
+import "./FiatSelector.scss";
+
 /**
  * Component which will display a currency button.
  */
-class FiatSelector extends Currency<unknown, CurrencyState> {
+class FiatSelector extends Currency<unknown, FiatSelectorState> {
+    /**
+     * The dropdown button class name.
+     */
+    private static readonly BUTTON_CLASSNAME: string = "fiat-selector__button";
+
+    /**
+     * The most used currencies shown on the top of the dropdown
+     */
+    private static readonly MOST_USED_CURRENCIES: string[] = ["EUR", "GBP", "USD", "TRY", "AUD"];
+
+    /**
+     * The dropdown reference.
+     */
+    private readonly dropdown: RefObject<HTMLDivElement>;
+
+    /**
+     * Create a new instance of FiatSelector.
+     * @param props The Props.
+     */
+    constructor(props: unknown) {
+        super(props);
+        this.dropdown = React.createRef();
+        this.setState({
+            isExpanded: false,
+            currencyNames: {}
+        });
+    }
+
+    /**
+     * The component did mount.
+     */
+    public componentDidMount(): void {
+        super.componentDidMount();
+
+        document.addEventListener("mousedown", this.outsideClickHandler);
+        this._currencyService.loadCurrencyNames().then(currencyNames => {
+            if (currencyNames) {
+                this.setState({ currencyNames });
+            }
+        })
+        .catch(_ => {});
+    }
+
+    /**
+     * The component is about to Unmount.
+     */
+    public componentWillUnmount() {
+        document.removeEventListener("mousedown", this.outsideClickHandler);
+    }
+
     /**
      * Render the component.
      * @returns The node to render.
      */
     public render(): ReactNode {
+        const renderCurrency = (currency: string) => (
+            <div
+                key={currency}
+                className="fiat-selector__currency"
+                onClick={() => {
+                    this.setCurrency(currency);
+                    this.updateCurrency();
+                    this.closeDropdown();
+                }}
+            >
+                <span className="acronym">{currency}</span>
+                <span className="full-name">{this.state?.currencyNames[currency]}</span>
+            </div>
+        );
+        const hasCurrencies = this.state?.currencies.length > 0;
+
         return (
-            <div className="select-wrapper">
-                <select
-                    value={this.state?.currency}
-                    onChange={e => {
-                        this.setCurrency(e.target.value);
-                        this.updateCurrency();
-                    }}
+            <div className="fiat-selector" >
+                <button
+                    type="button"
+                    className={FiatSelector.BUTTON_CLASSNAME}
+                    onClick={() => this.setState({ isExpanded: !this.state?.isExpanded })}
                 >
-                    {this.state?.currencies.map(cur => (
-                        <option value={cur} key={cur}>{cur}</option>
-                    ))}
-                </select>
+                    {this.state?.currency}
+                </button>
                 <img src={chevronDownGray} alt="expand" />
+                {
+                    this.state?.isExpanded &&
+                        <div className="fiat-selector__entries" ref={this.dropdown}>
+                            <div className="most-used">
+                                <div className="group-header">Most used currencies</div>
+                                {hasCurrencies &&
+                                    FiatSelector.MOST_USED_CURRENCIES.map(currency => renderCurrency(currency))}
+                            </div>
+                            <div>
+                                <div className="group-header">All currencies</div>
+                                {this.state?.currencies.map(currency => renderCurrency(currency))}
+                            </div>
+                        </div>
+                }
             </div>
         );
     }
@@ -34,6 +111,26 @@ class FiatSelector extends Currency<unknown, CurrencyState> {
      * Update formatted currencies.
      */
     protected updateCurrency(): void { }
+
+    /**
+     * Handler to detect clicks outside the dropdown
+     * @param event The click Event.
+     */
+    private readonly outsideClickHandler = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+        if (this.dropdown.current &&
+            !this.dropdown.current.contains(target) &&
+                target.className !== FiatSelector.BUTTON_CLASSNAME) {
+            this.closeDropdown();
+        }
+    };
+
+    /**
+     * Close the dropdown.
+     */
+    private readonly closeDropdown = () => {
+        this.setState({ isExpanded: false });
+    };
 }
 
 export default FiatSelector;

--- a/client/src/app/components/FiatSelectorState.ts
+++ b/client/src/app/components/FiatSelectorState.ts
@@ -1,0 +1,13 @@
+import { CurrencyState } from "./CurrencyState";
+
+export interface FiatSelectorState extends CurrencyState {
+    /**
+     * The dropdown expanded flag.
+     */
+    isExpanded: boolean;
+    /**
+     * The map of currency names.
+     */
+    currencyNames: { [id: string]: string };
+}
+

--- a/client/src/app/components/Footer.tsx
+++ b/client/src/app/components/Footer.tsx
@@ -2,7 +2,6 @@ import React, { Component, ReactNode } from "react";
 import logoFooter from "../../assets/logo-footer.svg";
 import { FoundationDataHelper } from "../../helpers/foundationDataHelper";
 import { ReactComponent as DiscordIcon } from "./../../assets/discord.svg";
-import { ReactComponent as FacebookIcon } from "./../../assets/facebook.svg";
 import { ReactComponent as GithubIcon } from "./../../assets/github.svg";
 import { ReactComponent as InstagramIcon } from "./../../assets/instagram.svg";
 import { ReactComponent as LinkedinIcon } from "./../../assets/linkedin.svg";

--- a/client/src/app/routes/Landing.tsx
+++ b/client/src/app/routes/Landing.tsx
@@ -198,7 +198,9 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                                     type="button"
                                                     className="button--unstyled toggle-filters-button"
                                                     onClick={() => {
-                                                        this.setState({ isFilterExpanded: !this.state.isFilterExpanded });
+                                                        this.setState(
+                                                            { isFilterExpanded: !this.state.isFilterExpanded }
+                                                        );
                                                     }}
                                                 >
                                                     <FilterIcon />
@@ -219,10 +221,12 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                                                 Reset
                                                             </button>
                                                             <span>Payload Filter</span>
-                                                            <button 
+                                                            <button
                                                                 className="done-button"
                                                                 type="button"
-                                                                onClick={() => this.setState({ isFilterExpanded: false })}
+                                                                onClick={() => this.setState(
+                                                                    { isFilterExpanded: false }
+                                                                )}
                                                             >
                                                                 Done
                                                             </button>

--- a/client/src/models/api/ICurrencyNamesResponse.ts
+++ b/client/src/models/api/ICurrencyNamesResponse.ts
@@ -1,0 +1,8 @@
+import { IResponse } from "./IResponse";
+
+export interface ICurrencyNamesResponse extends IResponse {
+    /**
+     * The currency acronym to name map.
+     */
+    currencyNames?: { [id: string]: string };
+}

--- a/client/src/models/services/ICurrencySettings.ts
+++ b/client/src/models/services/ICurrencySettings.ts
@@ -38,4 +38,14 @@ export interface ICurrencySettings {
          */
         rate: number;
     }[];
+
+    /**
+     * The currency id to full name map.
+     */
+    currencyNames?: {
+        /**
+         * Id to name key value pair.
+         */
+        [id: string]: string;
+    };
 }

--- a/client/src/services/apiClient.ts
+++ b/client/src/services/apiClient.ts
@@ -11,6 +11,7 @@ import { ISearchResponse } from "../models/api/chrysalis/ISearchResponse";
 import { ITransactionsDetailsRequest } from "../models/api/chrysalis/ITransactionsDetailsRequest";
 import { ITransactionsDetailsResponse } from "../models/api/chrysalis/ITransactionsDetailsResponse";
 import { ICurrenciesResponse } from "../models/api/ICurrenciesResponse";
+import { ICurrencyNamesResponse } from "../models/api/ICurrencyNamesResponse";
 import { IIdentityDidHistoryRequest } from "../models/api/IIdentityDidHistoryRequest";
 import { IIdentityDidHistoryResponse } from "../models/api/IIdentityDidHistoryResponse";
 import { IIdentityDidResolveRequest } from "../models/api/IIdentityDidResolveRequest";
@@ -64,6 +65,14 @@ export class ApiClient {
      */
     public async currencies(): Promise<ICurrenciesResponse> {
         return this.callApi<unknown, ICurrenciesResponse>("currencies", "get");
+    }
+
+    /**
+     * Perform a request to get currency names.
+     * @returns The response from the request.
+     */
+    public async currencyNames(): Promise<ICurrencyNamesResponse> {
+        return this.callApi<unknown, ICurrencyNamesResponse>("currency/names", "get");
     }
 
     /**

--- a/client/src/services/currencyService.ts
+++ b/client/src/services/currencyService.ts
@@ -252,6 +252,26 @@ export class CurrencyService {
     }
 
     /**
+     * Load the currency names data.
+     * @returns currencyNames The currency names map.
+     */
+    public async loadCurrencyNames(): Promise<{ [id: string]: string } | undefined> {
+        const settings = this._settingsService.get();
+
+        if (settings.currencyNames) {
+            return settings.currencyNames;
+        }
+
+        try {
+            const data = await this._apiClient.currencyNames();
+            settings.currencyNames = data.currencyNames;
+            return data.currencyNames;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
      * Save the fiat code to settings.
      * @param fiatCode The fiat code to save.
      */


### PR DESCRIPTION
# Description of change

- Added data population request (to Fixer API) which is performed on Services initialisation and stored in currency settings.
- Reworked implementation of FiatSelector.tsx to custom drop-down with currency names as per design [here](https://www.figma.com/file/j4RLa61iZ18VXwiabeyu9k/IOTA-Explorer-UI?node-id=1745%3A28396)

Aims to fix https://github.com/iotaledger/explorer/issues/223

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Currency drop-down displays currencies and selecting works.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
