### PR TITLE
Fix(client): Fix feed filter (re)initialisation when switching networks

### DIFF
--- a/client/src/app/routes/Landing.tsx
+++ b/client/src/app/routes/Landing.tsx
@@ -10,7 +10,7 @@ import { RouteBuilder } from "../../helpers/routeBuilder";
 import { INetwork } from "../../models/db/INetwork";
 import { IFeedItem } from "../../models/IFeedItem";
 import { IFilterSettings } from "../../models/services/IFilterSettings";
-import { ValueFilter } from "../../models/services/valueFilter";
+import { getDefaultValueFilter } from "../../models/services/valueFilter";
 import { NetworkService } from "../../services/networkService";
 import Feeds from "../components/Feeds";
 import { NumberHelper } from "./../../helpers/numberHelper";
@@ -22,36 +22,6 @@ import { LandingState } from "./LandingState";
  * Component which will show the landing page.
  */
 class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState> {
-    private readonly DEFAULT_VALUES_FILTER: ValueFilter[] = this._networkConfig?.protocolVersion === "og"
-        ? [
-            {
-                label: "Zero only",
-                isEnabled: true
-            },
-            {
-                label: "Non-zero only",
-                isEnabled: true
-            }
-        ]
-        : [
-            {
-                label: "Transaction",
-                isEnabled: true
-            },
-            {
-                label: "Milestone",
-                isEnabled: true
-            },
-            {
-                label: "Indexed",
-                isEnabled: true
-            },
-            {
-                label: "No payload",
-                isEnabled: true
-            }
-        ];
-
     /**
      * Create a new instance of Landing.
      * @param props The props.
@@ -74,7 +44,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
             valueMinimumUnits: "i",
             valueMaximum: "1",
             valueMaximumUnits: "Ti",
-            valuesFilter: this.DEFAULT_VALUES_FILTER,
+            valuesFilter: getDefaultValueFilter(network.protocolVersion),
             itemsPerSecond: "--",
             confirmedItemsPerSecond: "--",
             confirmedItemsPerSecondPercent: "--",
@@ -109,12 +79,15 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
             filterSettings = settings.filters[this._networkConfig.network];
         }
 
+        console.log(settings.filters);
+        
         this.setState({
             valueMinimum: filterSettings?.valueMinimum ?? "0",
             valueMinimumUnits: filterSettings?.valueMinimumUnits ?? "i",
             valueMaximum: filterSettings?.valueMaximum ?? "3",
             valueMaximumUnits: filterSettings?.valueMaximumUnits ?? "Pi",
-            valuesFilter: filterSettings?.valuesFilter ?? this.DEFAULT_VALUES_FILTER,
+            valuesFilter: filterSettings?.valuesFilter ??
+                getDefaultValueFilter(this._networkConfig?.protocolVersion ?? "chrysalis"),
             formatFull: settings.formatFull
         });
     }

--- a/client/src/app/routes/Landing.tsx
+++ b/client/src/app/routes/Landing.tsx
@@ -79,8 +79,6 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
             filterSettings = settings.filters[this._networkConfig.network];
         }
 
-        console.log(settings.filters);
-        
         this.setState({
             valueMinimum: filterSettings?.valueMinimum ?? "0",
             valueMinimumUnits: filterSettings?.valueMinimumUnits ?? "i",

--- a/client/src/models/services/valueFilter.ts
+++ b/client/src/models/services/valueFilter.ts
@@ -1,4 +1,42 @@
+import { ProtocolVersion } from "../db/protocolVersion";
+
 export interface ValueFilter {
     label: "Zero only" | "Non-zero only" | "Transaction" | "Milestone" | "Indexed" | "No payload";
     isEnabled: boolean;
 }
+
+/**
+ * Returns the default values for the Value Filter
+ * @param protocolVersion The Protocol Version string.
+ * @returns The filter ValueFilter(s) array
+ */
+export function getDefaultValueFilter(protocolVersion: ProtocolVersion): ValueFilter[] {
+    return protocolVersion === "og" ? [
+        {
+            label: "Zero only",
+            isEnabled: true
+        },
+        {
+            label: "Non-zero only",
+            isEnabled: true
+        }
+    ] : [
+        {
+            label: "Transaction",
+            isEnabled: true
+        },
+        {
+            label: "Milestone",
+            isEnabled: true
+        },
+        {
+            label: "Indexed",
+            isEnabled: true
+        },
+        {
+            label: "No payload",
+            isEnabled: true
+        }
+    ];
+}
+


### PR DESCRIPTION
- Fixed Feed Default Filter Values initialisation when switching networks. 

The issues was that `DEFAULT_VALUES_FILTER` was not recomputed when switching from "chrysalis" -> "og". So the filter options where the wrong ones and all the messages were filtered out leaving an empty feed.

Aims to fix https://github.com/iotaledger/explorer/issues/250

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Feed now works when switching to Legacy-mainnet and filters display correct values

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
