### PR TITLE
Fix: Change fiat acronym color from gray to white in currency dropdown.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -35488,6 +35488,7 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
         "bluebird": {
             "version": "3.7.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9419,7 +9419,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9984,7 +9983,6 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-            "devOptional": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -15620,7 +15618,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "devOptional": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -22609,7 +22606,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "devOptional": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -32760,7 +32756,6 @@
         },
         "@iota/mam-legacy": {
             "version": "git+ssh://git@github.com/iotaledger/mam.js.git#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
-            "integrity": "sha512-jY0dQoPIqznwrCKEiDyBe9gequO57NUMuLal3fnFudl7cat1UMFsUiR4yLm6wsP051ePUKXIRLXs2VWNoXbUmg==",
             "from": "@iota/mam-legacy@github:iotaledger/mam.js#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
             "requires": {
                 "@iota/core": "^1.0.0-beta.30",
@@ -35493,8 +35488,6 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "devOptional": true
         },
         "bluebird": {
             "version": "3.7.2",
@@ -35949,7 +35942,6 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-            "devOptional": true,
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -40316,7 +40308,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "devOptional": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -45710,7 +45701,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "devOptional": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9419,6 +9419,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9983,6 +9984,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "devOptional": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -15618,6 +15620,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "devOptional": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -22606,6 +22609,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "devOptional": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -32756,6 +32760,7 @@
         },
         "@iota/mam-legacy": {
             "version": "git+ssh://git@github.com/iotaledger/mam.js.git#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
+            "integrity": "sha512-jY0dQoPIqznwrCKEiDyBe9gequO57NUMuLal3fnFudl7cat1UMFsUiR4yLm6wsP051ePUKXIRLXs2VWNoXbUmg==",
             "from": "@iota/mam-legacy@github:iotaledger/mam.js#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
             "requires": {
                 "@iota/core": "^1.0.0-beta.30",
@@ -35488,7 +35493,8 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "devOptional": true
         },
         "bluebird": {
             "version": "3.7.2",
@@ -35943,6 +35949,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
             "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "devOptional": true,
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -40309,6 +40316,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "devOptional": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -45702,6 +45710,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "devOptional": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }

--- a/client/src/app/components/FiatSelector.scss
+++ b/client/src/app/components/FiatSelector.scss
@@ -84,7 +84,7 @@
       .acronym {
         width: 38px;
         margin-right: 8px;
-        color: $white;
+        color: var(--fiat-acronym-color);
         font-weight: 600;
         letter-spacing: 0.5px;
       }

--- a/client/src/app/components/FiatSelector.scss
+++ b/client/src/app/components/FiatSelector.scss
@@ -84,7 +84,7 @@
       .acronym {
         width: 38px;
         margin-right: 8px;
-        color: $gray-11;
+        color: $white;
         font-weight: 600;
         letter-spacing: 0.5px;
       }

--- a/client/src/scss/themes.scss
+++ b/client/src/scss/themes.scss
@@ -16,6 +16,7 @@
   --header-icon-color: #{$gray-7};
   --header-svg-bg: #{$gray-2};
   --border-color: #{$gray-3};
+  --fiat-acronym-color: #{$gray-11};
   --expanded-color: #{$gray-7};
   --light-bg: #{$gray-1};
   --input-border-color: #d9e1ef;
@@ -56,6 +57,7 @@
     --header-icon-color: #{$gray-5};
     --header-svg-bg: #202e4a;
     --border-color: #ffffff1e;
+    --fiat-acronym-color: #{$white};
     --expanded-color: #{$gray-5};
     --light-bg: #48577614;
     --input-border-color: #{$gray-5};


### PR DESCRIPTION
# Description of change

In this PR i have implemented dark mode for currency dropdown. For this i have changed the color from gray to white of fiat acronym in the dropdown.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

This change can be test visually.

