### PR TITLE
Fix: Improve transaction history (sorting)

### DIFF
--- a/client/src/app/components/chrysalis/Transaction.tsx
+++ b/client/src/app/components/chrysalis/Transaction.tsx
@@ -49,7 +49,7 @@ class Transaction extends Component<TransactionProps, TransactionState> {
                             : <Spinner />}
                     </td>
                     <td className={`amount ${this.props.amount && this.props.amount < 0 ? "negative" : "positive"}`}>
-                        {this.props.amount ? UnitsHelper.formatBest(this.props.amount ?? 0) : <Spinner />}
+                        {this.props.amount !== undefined ? UnitsHelper.formatBest(this.props.amount ?? 0) : <Spinner />}
                     </td>
                 </tr>
             ) : (

--- a/client/src/app/routes/chrysalis/Addr.tsx
+++ b/client/src/app/routes/chrysalis/Addr.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
 import { Bech32AddressHelper } from "../../../helpers/bech32AddressHelper";
 import { TransactionsHelper } from "../../../helpers/transactionsHelper";
-import {HistoricInput, HistoricOutput, ITransaction} from "../../../models/api/chrysalis/ITransactionsDetailsResponse";
+import { HistoricInput, HistoricOutput, ITransaction } from "../../../models/api/chrysalis/ITransactionsDetailsResponse";
 import { NetworkService } from "../../../services/networkService";
 import { TangleCacheService } from "../../../services/tangleCacheService";
 import AsyncComponent from "../../components/AsyncComponent";
@@ -316,19 +316,20 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
     private get currentPageTransactions() {
         const firstPageIndex = (this.state.currentPage - 1) * this.state.pageSize;
         const lastPageIndex = firstPageIndex + this.state.pageSize;
-        const transactionsPage = this.txsHistory.
-            slice(firstPageIndex, lastPageIndex).
-            reduce((acc: ITransaction[], curr: ITransaction) => {
+        const transactionsPage = this.txsHistory
+        .slice(firstPageIndex, lastPageIndex)
+        /* eslint-disable-next-line unicorn/no-array-reduce */
+        .reduce((acc: ITransaction[], curr: ITransaction) => {
             acc.push(curr);
             if (curr.relatedSpentTransaction) {
                 acc.push(curr.relatedSpentTransaction);
             }
-            return acc
+            return acc;
         }, []);
 
-        const sortedTransactions: ITransaction[] = transactionsPage.sort((a, b) =>
-            moment(a.date).isAfter(moment(b.date)) ? -1 : 1
-        );
+        const sortedTransactions: ITransaction[] = transactionsPage.sort((a, b) => (
+             moment(a.date).isAfter(moment(b.date)) ? -1 : 1
+        ));
         return sortedTransactions;
     }
 
@@ -433,21 +434,21 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
 
                             if (transactionsResult?.message?.payload?.type === TRANSACTION_PAYLOAD_TYPE) {
                                 const relatedAmount = await this.getTransactionAmount(output.spendingMessageId);
-                                const historicInputs: HistoricInput[] = transactionsResult?.message?.
-                                    payload?.essence?.inputs.map(input => ({
+                                const relatedInputs = transactionsResult?.message?.payload?.essence?.inputs;
+                                const historicInputs: HistoricInput[] = relatedInputs.map(input => ({
                                     transactionId: input.transactionId,
                                     transactionOutputIndex: input.transactionOutputIndex.toString(),
                                     type: input.type
                                 }));
-                                const historicOutputs: HistoricOutput[] = transactionsResult?.message?.
-                                    payload?.essence?.outputs.map(output => ({
+                                const relatedOutputs = transactionsResult?.message?.payload?.essence?.outputs;
+                                const historicOutputs: HistoricOutput[] = relatedOutputs.map(relatedOutput => ({
                                     output: {
                                         address: {
-                                            type: output.address.type,
-                                            address: output.address.address
+                                            type: relatedOutput.address.type,
+                                            address: relatedOutput.address.address
                                         },
-                                        amount: output.amount.toString(),
-                                        type: output.type
+                                        amount: relatedOutput.amount.toString(),
+                                        type: relatedOutput.type
                                     },
                                     spendingMessageId: ""
                                 }));

--- a/client/src/app/routes/chrysalis/Addr.tsx
+++ b/client/src/app/routes/chrysalis/Addr.tsx
@@ -32,7 +32,7 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
     /**
      * Maximum page size for permanode request.
      */
-     private static readonly MAX_PAGE_SIZE: number = 6000;
+     private static readonly MAX_PAGE_SIZE: number = 500;
 
     /**
      * API Client for tangle requests.
@@ -348,6 +348,7 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
                 const firstPageIndex = (this.state.currentPage - 1) * this.state.pageSize;
                 const lastPageIndex = (this.state.currentPage === Math.ceil(this.txsHistory.length / this.state.pageSize))
                     ? this.txsHistory.length : firstPageIndex + this.state.pageSize;
+
                 this.updateTransactionHistoryDetails(firstPageIndex, lastPageIndex)
                     .catch(err => console.error(err));
 
@@ -364,6 +365,15 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
                                 transactions: allTransactionsDetails.transactionHistory
                                     .transactions?.map(t1 => ({ ...t1, ...this.txsHistory.find(t2 => t2.messageId === t1.messageId) })),
                                 state: allTransactionsDetails.transactionHistory.state } } });
+                    }
+
+                    if (allTransactionsDetails?.transactionHistory?.state) {
+                        return this._tangleCacheService.transactionsDetails({
+                            network: this.props.match.params.network,
+                            address: this.state.address?.address ?? "",
+                            query: { page_size: Addr.MAX_PAGE_SIZE, state: transactionsDetails?.transactionHistory.state }
+                        },
+                        true);
                     }
                 }
 

--- a/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
+++ b/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
@@ -55,36 +55,7 @@ export interface ITransaction {
     /**
      * Transaction which is consumed related to the current transaction.
      */
-    relatedSpentTransaction?: {
-        /**
-         * The message id the output was contained in.
-         */
-        messageId: string;
-        /**
-         * Message status
-         */
-        messageTangleStatus: MessageTangleStatus;
-        /**
-         * The inputs.
-         */
-        inputs: IUTXOInput[];
-        /**
-         * Date of Milestone Reference.
-         */
-        date?: string;
-        /**
-         * The outputs.
-         */
-        outputs: (ISigLockedDustAllowanceOutput | ISigLockedSingleOutput)[];
-        /**
-         * Show if a transation is spent or not.
-         */
-        isSpent?: boolean;
-        /**
-         * Amount of transaction.
-         */
-        amount?: number;
-    };
+    relatedSpentTransaction?: ITransaction;
     /**
      * Is transaction included in ledger.
      */

--- a/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
+++ b/client/src/models/api/chrysalis/ITransactionsDetailsResponse.ts
@@ -1,4 +1,3 @@
-import { ISigLockedDustAllowanceOutput, ISigLockedSingleOutput, IUTXOInput } from "@iota/iota.js";
 import { MessageTangleStatus } from "../../messageTangleStatus";
 import { IResponse } from "../IResponse";
 export interface HistoricOutput {

--- a/client/src/services/tangleCacheService.ts
+++ b/client/src/services/tangleCacheService.ts
@@ -842,6 +842,7 @@ export class TangleCacheService {
         if (!this._chrysalisSearchCache[request.network][`${request.address}--transaction-history`]
             ?.data?.transactionHistory || skipCache) {
             const apiClient = ServiceFactory.get<ApiClient>("api-client");
+
             const response = await apiClient.transactionsDetails(request);
 
             if (response?.transactionHistory?.transactions) {
@@ -863,15 +864,6 @@ export class TangleCacheService {
                     },
                     cached: Date.now()
                 };
-            }
-
-            if (response?.transactionHistory?.state) {
-                return this.transactionsDetails({
-                    network: request.network,
-                    address: request.address,
-                    query: { page_size: request.query?.page_size, state: response.transactionHistory.state }
-                },
-                    skipCache);
             }
         }
 


### PR DESCRIPTION
# Description of change

- Sorted transactions and "relatedTransaction" (spending ones)
- Lowered MAX_PAGE_SIZE
- Removed a recursive call so we see "batches" data sooner

Transactions are now sorted by descending date "per page". Switching pages triggers fetching of "relatedTransactions" for transactions and sorting. 
Large histories will still have inconsistent sorting "across pages".

Aims to fix https://github.com/iotaledger/explorer/issues/129

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Visually

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
