### PR TITLE
Feat: Update network selector headings

### DIFF
--- a/client/src/app/components/Header.tsx
+++ b/client/src/app/components/Header.tsx
@@ -45,9 +45,10 @@ class Header extends Component<HeaderProps, HeaderState> {
 
         const PROTOCOLS = [
             {
-                label: "IOTA 2.0 (Stardust)",
-                description: "Stardust Testnet (alphanet)",
-                networks: STARDUST_NETWORKS
+                label: "IOTA 1.0 (Legacy)",
+                description:
+                    "Legacy network that only accepts migrations to the IOTA 1.5 (Chrysalis) network.",
+                networks: LEGACY_NETWORKS
             },
             {
                 label: "IOTA 1.5 (Chrysalis)",
@@ -56,10 +57,9 @@ class Header extends Component<HeaderProps, HeaderState> {
                 networks: CHRYSALIS_NETWORKS
             },
             {
-                label: "IOTA 1.0 (Legacy)",
-                description:
-                    "Legacy network that only accepts migrations to the IOTA 1.5 (Chrysalis) network.",
-                networks: LEGACY_NETWORKS
+                label: "IOTA Stardust",
+                description: "Stardust Testnet.",
+                networks: STARDUST_NETWORKS
             }
         ];
         return (

--- a/client/src/app/components/NetworkSwitcher.scss
+++ b/client/src/app/components/NetworkSwitcher.scss
@@ -86,6 +86,10 @@
       grid-template-rows: auto 1fr;
       padding: 0 24px;
 
+      .protocol-heading {
+        height: 50px;
+      }
+
       .protocol--title {
         color: var(--expanded-color);
         font-family: $metropolis;
@@ -105,9 +109,8 @@
       }
 
       .network--cards {
-        display: grid;
-        grid-template-columns: 1fr;
-        grid-template-rows: 1fr 1fr;
+        display: flex;
+        flex-direction: column;
         padding-top: 44px;
 
         .network--card {

--- a/client/src/app/components/NetworkSwitcher.tsx
+++ b/client/src/app/components/NetworkSwitcher.tsx
@@ -40,7 +40,7 @@ class NetworkSwitcher extends Component<NetworkSwitcherProps> {
                         <div className="protocols">
                             {this.props.protocols.map(protocol => (
                                 <div className="protocol" key={protocol.label}>
-                                    <div >
+                                    <div className="protocol-heading">
                                         <div className="protocol--title">{protocol.label}</div>
                                         <div className="protocol--description">
                                             {protocol.description}


### PR DESCRIPTION
# Description of change

Network selector design update. Now it looks like this:

![Screenshot 2022-05-12 at 5 29 05 PM](https://user-images.githubusercontent.com/101638386/168074910-2c4a3318-7f60-4ce2-b629-056cfb26ce75.png)

Aims to compete https://github.com/iotaledger/explorer/issues/288

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Visually.
