### PR TITLE
Fix: Address minor issue with inclusion state for relatedTransactions in Add.tsx

### DIFF
--- a/client/src/app/routes/chrysalis/Addr.tsx
+++ b/client/src/app/routes/chrysalis/Addr.tsx
@@ -466,7 +466,7 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
                                     amount: relatedAmount,
                                     inputs: historicInputs,
                                     outputs: historicOutputs,
-                                    ledgerInclusionState: statusDetails.messageTangleStatus
+                                    ledgerInclusionState: "included"
                                 };
                                 if (relatedAmount < 0) {
                                     this.setState({ sent: this.state.sent + Math.abs(relatedAmount) });


### PR DESCRIPTION
# Description of change

- Fix minor issues that sometimes happens when loading transaction history where status in column displays "PendingConflicting" and gets stuck loading (page refresh makes it disappear)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
