### PR TITLE
Feat: Update network selector

### DIFF
--- a/client/src/app/components/Header.tsx
+++ b/client/src/app/components/Header.tsx
@@ -43,25 +43,7 @@ class Header extends Component<HeaderProps, HeaderState> {
             n => n.protocolVersion === OG
         );
 
-        const PROTOCOLS = [
-            {
-                label: "IOTA 1.0 (Legacy)",
-                description:
-                    "Legacy network that only accepts migrations to the IOTA 1.5 (Chrysalis) network.",
-                networks: LEGACY_NETWORKS
-            },
-            {
-                label: "IOTA 1.5 (Chrysalis)",
-                description:
-                    "The latest IOTA network deployed in April 2021.",
-                networks: CHRYSALIS_NETWORKS
-            },
-            {
-                label: "IOTA Stardust",
-                description: "Stardust Testnet.",
-                networks: STARDUST_NETWORKS
-            }
-        ];
+        const PROTOCOLS = getProtocols();
         return (
             <header>
                 <nav className="inner">
@@ -272,6 +254,35 @@ class Header extends Component<HeaderProps, HeaderState> {
                 </nav>
             </header >
         );
+
+        /**
+         * Get protocol from configuration
+         * @returns The filtered protocols.
+         */
+        function getProtocols() {
+            let protocols = [
+                {
+                    label: "IOTA 1.0 (Legacy)",
+                    description:
+                        "Legacy network that only accepts migrations to the IOTA 1.5 (Chrysalis) network.",
+                    networks: LEGACY_NETWORKS
+                },
+                {
+                    label: "IOTA 1.5 (Chrysalis)",
+                    description:
+                        "The latest IOTA network deployed in April 2021.",
+                    networks: CHRYSALIS_NETWORKS
+                },
+                {
+                    label: "IOTA Stardust",
+                    description:
+                        "Stardust Testnet.",
+                    networks: STARDUST_NETWORKS
+                }
+            ];
+            protocols = protocols.filter(protocol => protocol.networks && protocol.networks.length > 0);
+            return protocols;
+        }
     }
 
     /**

--- a/client/src/app/components/NetworkSwitcher.scss
+++ b/client/src/app/components/NetworkSwitcher.scss
@@ -111,7 +111,6 @@
       .network--cards {
         display: flex;
         flex-direction: column;
-        padding-top: 44px;
 
         .network--card {
           min-height: 86px;

--- a/client/src/app/components/NetworkSwitcher.tsx
+++ b/client/src/app/components/NetworkSwitcher.tsx
@@ -40,12 +40,6 @@ class NetworkSwitcher extends Component<NetworkSwitcherProps> {
                         <div className="protocols">
                             {this.props.protocols.map(protocol => (
                                 <div className="protocol" key={protocol.label}>
-                                    <div className="protocol-header">
-                                        <div className="protocol--title">{protocol.label}</div>
-                                        <div className="protocol--description">
-                                            {protocol.description}
-                                        </div>
-                                    </div>
                                     <div className="network--cards">
                                         {protocol.networks?.map(n => (
                                             <div
@@ -70,6 +64,18 @@ class NetworkSwitcher extends Component<NetworkSwitcherProps> {
                                                 </div>
                                             </div>
                                         ))}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="protocols">
+                            {this.props.protocols.map(protocol => (
+                                <div className="protocol" key={protocol.label}>
+                                    <div className="protocol-header">
+                                        <div className="protocol--title">{protocol.label}</div>
+                                        <div className="protocol--description">
+                                            {protocol.description}
+                                        </div>
                                     </div>
                                 </div>
                             ))}

--- a/client/src/app/routes/stardust/Message.tsx
+++ b/client/src/app/routes/stardust/Message.tsx
@@ -443,7 +443,8 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
             );
 
             if (result?.message?.payload?.type === TRANSACTION_PAYLOAD_TYPE) {
-                const transactionId = TransactionsHelper.computeTransactionIdFromTransactionPayload(result?.message.payload);
+                const transactionId =
+                    TransactionsHelper.computeTransactionIdFromTransactionPayload(result?.message.payload);
                 this.setState({ transactionId });
             }
 


### PR DESCRIPTION
# Description of change

Update network selector so that networks will be listed on top and protocols will be listed below.
Below attached is the screenshot for the visual experience that how the network selector will look now. 

![Screenshot 2022-05-23 at 3 50 00 PM](https://user-images.githubusercontent.com/101638386/169804034-9fab6f0e-9d8a-4f03-a8c2-78b1003da2b9.png)

**Note** I have added test networks for testing purposes.
Aims to complete https://github.com/iotaledger/explorer/issues/295

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Add or remove networks in `.localstorage` and rebuild the project to see the changes.
