### PR TITLE
fix: resolve TS issues in transactionHelper

### DIFF
--- a/client/src/helpers/chrysalis/transactionsHelper.ts
+++ b/client/src/helpers/chrysalis/transactionsHelper.ts
@@ -65,11 +65,11 @@ export class TransactionsHelper {
             }
 
             for (let i = 0; i < transactionMessage.payload.essence.inputs.length; i++) {
-                const input = transactionMessage.payload.essence.inputs[i];
+                const input: IUTXOInput = transactionMessage.payload.essence.inputs[i];
                 const isGenesis = input.transactionId === GENESIS_HASH;
                 const writeOutputStream = new WriteStream();
                 writeOutputStream.writeUInt16("transactionOutputIndex", input.transactionOutputIndex);
-                const outputHash = input.transactionId + writeOutputStream.finalHex();
+                const outputHash = `${input.transactionId}${writeOutputStream.finalHex()}`;
                 const transactionOutputIndex = input.transactionOutputIndex;
                 const transactionResult = await tangleCacheService.search(
                     network, input.transactionId);


### PR DESCRIPTION
# Description of change

Fixes for the following issues:

```
  72:36  error  Operands of '+' operation must either be both strings or both numbers. Consider using a template literal  @typescript-eslint/restrict-plus-operands
```
&

```
TypeScript error in /Users/umair/workspace/explorer/client/src/helpers/chrysalis/transactionsHelper.ts(68,23):
'input' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

By building `client/`

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
