### PR TITLE
Feat: Display id's in output on block page.

### DIFF
--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -34,6 +34,7 @@ class Output extends Component<OutputProps, OutputState> {
 
         this.state = {
             output: props.output,
+            outputId: props.id,
             showOutputDetails: -1
         };
     }
@@ -49,6 +50,25 @@ class Output extends Component<OutputProps, OutputState> {
             <div className="output margin-l-t">
                 {this.state.output.type === ALIAS_OUTPUT_TYPE && (
                     <React.Fragment>
+                        <div className="card--label">
+                            Output id:
+                        </div>
+                        <div className="card--value row middle">
+                            <button
+                                type="button"
+                                className="margin-r-t"
+                                onClick={() => this.props.history?.push(
+                                    `/${this.props.network
+                                    }/block/${this.state.outputId}`)}
+                            >
+                                {this.state.outputId}
+                            </button>
+                            <CopyButton
+                                onClick={() => ClipboardHelper.copy(this.state.outputId)}
+                                buttonType="copy"
+                                labelPosition="top"
+                            />
+                        </div>
                         <div className="card--label">
                             Alias id:
                         </div>
@@ -89,6 +109,25 @@ class Output extends Component<OutputProps, OutputState> {
                 {this.state.output.type === NFT_OUTPUT_TYPE && (
                     <React.Fragment>
                         <div className="card--label">
+                            Output id:
+                        </div>
+                        <div className="card--value row middle">
+                            <button
+                                type="button"
+                                className="margin-r-t"
+                                onClick={() => this.props.history?.push(
+                                    `/${this.props.network
+                                    }/block/${this.state.outputId}`)}
+                            >
+                                {this.state.outputId}
+                            </button>
+                            <CopyButton
+                                onClick={() => ClipboardHelper.copy(this.state.outputId)}
+                                buttonType="copy"
+                                labelPosition="top"
+                            />
+                        </div>
+                        <div className="card--label">
                             Nft id:
                         </div>
                         <div className="card--value row">
@@ -109,6 +148,25 @@ class Output extends Component<OutputProps, OutputState> {
 
                 {this.state.output.type === FOUNDRY_OUTPUT_TYPE && (
                     <React.Fragment>
+                        <div className="card--label">
+                            Output id:
+                        </div>
+                        <div className="card--value row middle">
+                            <button
+                                type="button"
+                                className="margin-r-t"
+                                onClick={() => this.props.history?.push(
+                                    `/${this.props.network
+                                    }/block/${this.state.outputId}`)}
+                            >
+                                {this.state.outputId}
+                            </button>
+                            <CopyButton
+                                onClick={() => ClipboardHelper.copy(this.state.outputId)}
+                                buttonType="copy"
+                                labelPosition="top"
+                            />
+                        </div>
                         <div className="card--label">
                             Serial number:
                         </div>

--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -59,7 +59,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 className="margin-r-t"
                                 onClick={() => this.props.history?.push(
                                     `/${this.props.network
-                                    }/block/${this.state.outputId}`)}
+                                    }/search/${this.state.outputId}`)}
                             >
                                 {this.state.outputId}
                             </button>
@@ -117,7 +117,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 className="margin-r-t"
                                 onClick={() => this.props.history?.push(
                                     `/${this.props.network
-                                    }/block/${this.state.outputId}`)}
+                                    }/search/${this.state.outputId}`)}
                             >
                                 {this.state.outputId}
                             </button>
@@ -157,7 +157,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 className="margin-r-t"
                                 onClick={() => this.props.history?.push(
                                     `/${this.props.network
-                                    }/block/${this.state.outputId}`)}
+                                    }/search/${this.state.outputId}`)}
                             >
                                 {this.state.outputId}
                             </button>

--- a/client/src/app/components/stardust/OutputProps.tsx
+++ b/client/src/app/components/stardust/OutputProps.tsx
@@ -1,5 +1,4 @@
 import { OutputTypes } from "@iota/iota.js-stardust";
-import * as H from "history";
 
 export interface OutputProps {
     /**
@@ -28,11 +27,6 @@ export interface OutputProps {
     hideLabel?: boolean;
 
     /**
-     * History for navigation.
-     */
-    history: H.History;
-
-     /**
      * The network to lookup.
      */
     network: string;

--- a/client/src/app/components/stardust/OutputProps.tsx
+++ b/client/src/app/components/stardust/OutputProps.tsx
@@ -1,4 +1,5 @@
 import { OutputTypes } from "@iota/iota.js-stardust";
+import * as H from "history";
 
 export interface OutputProps {
     /**
@@ -25,4 +26,14 @@ export interface OutputProps {
      * Should hide the label.
      */
     hideLabel?: boolean;
+
+    /**
+     * History for navigation.
+     */
+    history: H.History;
+
+     /**
+     * The network to lookup.
+     */
+    network: string;
 }

--- a/client/src/app/components/stardust/OutputState.tsx
+++ b/client/src/app/components/stardust/OutputState.tsx
@@ -6,6 +6,10 @@ export interface OutputState {
      */
     output: OutputTypes;
     /**
+     * The output id.
+     */
+    outputId: string;
+    /**
      * Shows details of the specified output id
      */
     showOutputDetails: number;

--- a/client/src/app/components/stardust/OutputState.tsx
+++ b/client/src/app/components/stardust/OutputState.tsx
@@ -6,10 +6,6 @@ export interface OutputState {
      */
     output: OutputTypes;
     /**
-     * The output id.
-     */
-    outputId: string;
-    /**
      * Shows details of the specified output id
      */
     showOutputDetails: number;

--- a/client/src/app/components/stardust/TransactionPayload.tsx
+++ b/client/src/app/components/stardust/TransactionPayload.tsx
@@ -185,6 +185,8 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                                 index={idx + 1}
                                                 output={output.output}
                                                 amount={output.amount}
+                                                network={this.props.network}
+                                                history={this.props.history}
                                             />
                                         </div>
                                     )}

--- a/client/src/app/components/stardust/TransactionPayload.tsx
+++ b/client/src/app/components/stardust/TransactionPayload.tsx
@@ -186,7 +186,6 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                                 output={output.output}
                                                 amount={output.amount}
                                                 network={this.props.network}
-                                                history={this.props.history}
                                             />
                                         </div>
                                     )}


### PR DESCRIPTION
# Description of change

- Display foundry id, alias id and nft id in there respective outputs.
- Add copy button to copy these id's.
- Add link so that on clicking it takes to the corresponding Foundry/Alias/NFT page.

Aims to complete https://github.com/iotaledger/explorer/issues/311

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code

