### PR TITLE
Feat: Show full Addresses on Message and Address pages

### DIFF
--- a/client/src/app/components/MessageTree.scss
+++ b/client/src/app/components/MessageTree.scss
@@ -51,7 +51,8 @@
     background-color: var(--message-tree-bg);
     color: var(--expanded-color);
     font-family: $ibm-plex-mono;
-    font-weight: 600;
+    font-weight: 400;
+    font-size: 0.65rem;
     letter-spacing: 0.5px;
     cursor: pointer;
   }

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -10,8 +10,8 @@ import { EdgeUI, ItemUI, MessageTreeState, TreeConfig } from "./MessageTreeState
 const DESKTOP_CONFIG: TreeConfig = {
     verticalSpace: 20,
     horizontalSpace: 80,
-    itemHeight: 32,
-    itemWidth: 205
+    itemHeight: 40,
+    itemWidth: 300
 };
 
 /**
@@ -151,9 +151,11 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 width: `${this.state.config.itemWidth}px`,
                                 left: item.type === "parent" ? "0" : "none",
                                 right: item.type === "child" ? "0" : "none",
-                                top: `${item.top}px`
+                                top: `${item.top}px`,
+                                wordBreak: this.state.config === DESKTOP_CONFIG ? "break-word" : "normal",
+                                textAlign: "center"
                             }}
-                            className={item.type}
+                            className="parent"
                             key={item.id}
                             onClick={() => {
                                 this.scrollToMessageTree();
@@ -162,22 +164,30 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 });
                             }}
                         >
-                            {item.id.slice(0, this.state.config === DESKTOP_CONFIG
-                                ? 6 : 4)}...{item.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
+                            {
+                                this.state.config === DESKTOP_CONFIG
+                                    ? item.id
+                                    : <span>{item.id.slice(0, 4)}...{item.id.slice(-4)}</span>
+                            }
                         </div>
                     ))}
 
                     {/* Root */}
                     <div
-                        className="root"
+                        className="root parent"
                         style={{
                             height: `${this.state.config.itemHeight}px`,
-                            width: `${this.state.config.itemWidth}px`
+                            width: `${this.state.config.itemWidth}px`,
+                            wordBreak: this.state.config === DESKTOP_CONFIG ? "break-word" : "normal",
+                            textAlign: "center"
                         }}
                     >
-                        {this.state.currentMessage.slice(0, this.state.config === DESKTOP_CONFIG
-                            ? 6 : 4)}...{this.state.currentMessage.slice(this.state.config === DESKTOP_CONFIG
-                                ? -6 : -4)}
+                        {
+                            this.state.config === DESKTOP_CONFIG
+                                ? this.state.currentMessage
+                                // eslint-disable-next-line max-len
+                                : <span>{this.state.currentMessage.slice(0, 4)}...{this.state.currentMessage.slice(-4)}</span>
+                        }
                     </div>
 
                     {/* Edges */}

--- a/client/src/app/components/chrysalis/Bech32Address.tsx
+++ b/client/src/app/components/chrysalis/Bech32Address.tsx
@@ -50,7 +50,7 @@ class Bech32Address extends Component<Bech32AddressProps> {
                             {!this.props.history && (
                                 <span className="margin-r-t">{this.props.addressDetails.bech32}</span>
                             )}
-                            {!this.props.truncateAddress && (
+                            {this.props.showCopyButton && (
                                 <MessageButton
                                     onClick={() => ClipboardHelper.copy(this.props.addressDetails?.bech32)}
                                     buttonType="copy"

--- a/client/src/app/components/chrysalis/Bech32AddressProps.tsx
+++ b/client/src/app/components/chrysalis/Bech32AddressProps.tsx
@@ -31,4 +31,9 @@ export interface Bech32AddressProps {
      * Truncate address.
      */
     truncateAddress?: boolean;
+
+    /**
+     * Show copy button.
+     */
+    showCopyButton?: boolean;
 }

--- a/client/src/app/components/chrysalis/ReceiptPayload.tsx
+++ b/client/src/app/components/chrysalis/ReceiptPayload.tsx
@@ -85,6 +85,7 @@ class ReceiptPayload extends Component<ReceiptPayloadProps, ReceiptPayloadState>
                                     advancedMode={this.props.advancedMode}
                                     history={this.props.history}
                                     network={this.props.network}
+                                    showCopyButton={true}
                                 />
                             </div>
                             <div className="card--label">

--- a/client/src/app/components/chrysalis/Transaction.tsx
+++ b/client/src/app/components/chrysalis/Transaction.tsx
@@ -28,7 +28,7 @@ class Transaction extends Component<TransactionProps, TransactionState> {
                             }
                             className="margin-r-t"
                         >
-                            {this.props.messageId.slice(0, 12)}...{this.props.messageId.slice(-12)}
+                            {this.props.messageId}
                         </Link>
                     </td>
                     <td>{this.props.date
@@ -64,7 +64,7 @@ class Transaction extends Component<TransactionProps, TransactionState> {
                                 }
                                 className="margin-r-t"
                             >
-                                {this.props.messageId.slice(0, 12)}...{this.props.messageId.slice(-12)}
+                                {this.props.messageId}
                             </Link>
                         </div>
                     </div>

--- a/client/src/app/components/chrysalis/TransactionPayload.scss
+++ b/client/src/app/components/chrysalis/TransactionPayload.scss
@@ -63,6 +63,11 @@
         color: var(--type-color);
       }
 
+      .amount-size {
+        width: 200px;
+        text-align: end;
+      }
+
       .bech32-address {
         .value {
           @include font-size(14px);

--- a/client/src/app/components/chrysalis/TransactionPayload.tsx
+++ b/client/src/app/components/chrysalis/TransactionPayload.tsx
@@ -89,9 +89,10 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                             addressDetails={input.transactionAddress}
                                             advancedMode={false}
                                             hideLabel
-                                            truncateAddress
+                                            truncateAddress={false}
+                                            showCopyButton={false}
                                         />
-                                        <div className="card--value">
+                                        <div className="card--value amount-size">
                                             {UnitsHelper.formatBest(input.amount)}
                                         </div>
                                     </div>
@@ -107,6 +108,7 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                                     advancedMode
                                                     hideLabel
                                                     truncateAddress={false}
+                                                    showCopyButton={true}
                                                 />
                                             </div>
                                             <div className="card--label"> Transaction Id</div>
@@ -152,9 +154,10 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                             addressDetails={output.address}
                                             advancedMode={false}
                                             hideLabel
-                                            truncateAddress
+                                            truncateAddress={false}
+                                            showCopyButton={false}
                                         />
-                                        <div className="card--value">
+                                        <div className="card--value amount-size">
                                             {UnitsHelper.formatBest(output.amount)}
                                         </div>
                                     </div>
@@ -170,6 +173,7 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                                     advancedMode
                                                     hideLabel
                                                     truncateAddress={false}
+                                                    showCopyButton={true}
                                                 />
                                             </div>
                                         </React.Fragment>)}

--- a/client/src/app/routes/chrysalis/Addr.tsx
+++ b/client/src/app/routes/chrysalis/Addr.tsx
@@ -140,6 +140,7 @@ class Addr extends AsyncComponent<RouteComponentProps<AddrRouteProps>, AddrState
                                             <Bech32Address
                                                 addressDetails={this.state.bech32AddressDetails}
                                                 advancedMode={true}
+                                                showCopyButton={true}
                                             />
                                             {/* {!this.state.statusBusy && (
                                                 <div className="row row--tablet-responsive">


### PR DESCRIPTION
# Description of change

- Display full address on message page under transaction payload.
- Display full message id's in message tree. For mobile screens the id's will still be truncated as there is not enough space to show the complete id's.
- Display full message id's in transaction history table.

Aims to complete https://github.com/iotaledger/explorer/issues/313

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
