### PR TITLE
Fix: Improve amount computing for Inputs

### DIFF
--- a/client/src/helpers/stardust/transactionsHelper.ts
+++ b/client/src/helpers/stardust/transactionsHelper.ts
@@ -65,6 +65,7 @@ export class TransactionsHelper {
 
             // Inputs
             for (let i = 0; i < payload.essence.inputs.length; i++) {
+                let amount = 0;
                 let transactionUrl;
                 let transactionAddress = unlockAddresses[i];
                 const input = payload.essence.inputs[i];
@@ -77,19 +78,21 @@ export class TransactionsHelper {
 
                 transactionUrl = `/${network}/search/${outputHash}`;
 
-                const inputSearchResponse = await tangleCacheService.search(network, input.transactionId);
-                const inputTransaction = inputSearchResponse?.block;
-                const amount = (inputTransaction?.payload?.type === TRANSACTION_PAYLOAD_TYPE)
-                    ? Number(inputTransaction.payload?.essence.outputs[transactionOutputIndex].amount) : 0;
-
                 const outputResponse = await tangleCacheService.outputDetails(network, outputHash);
-                if (outputResponse && outputResponse?.output.type !== TREASURY_OUTPUT_TYPE) {
-                    const address: IBech32AddressDetails = TransactionsHelper
-                    .bechAddressFromAddressUnlockCondition(outputResponse.output.unlockConditions,
-                                                         _bechHrp, outputResponse.output.type);
-                    if (address.bech32 !== "") {
-                        transactionAddress = address;
-                        transactionUrl = `/${network}/message/${outputResponse.metadata.blockId}`;
+                if (outputResponse) {
+                    amount = Number(outputResponse.output.amount);
+
+                    if (outputResponse.output.type !== TREASURY_OUTPUT_TYPE) {
+                        const address: IBech32AddressDetails = TransactionsHelper.bechAddressFromAddressUnlockCondition(
+                            outputResponse.output.unlockConditions,
+                            _bechHrp,
+                            outputResponse.output.type
+                        );
+
+                        if (address.bech32 !== "") {
+                            transactionAddress = address;
+                            transactionUrl = `/${network}/message/${outputResponse.metadata.blockId}`;
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description of change

When building the input data from block payload, we displayed the amount from the {transactionId}/included-block API call, which wasn't returning for on input of this block as probably the message that generated the input (as output) was already pruned.
Amount can also be fetched from the actual output fetched directly, and this was done anyway couple lines below.

#### Changes
- Remove the call to included-block
- Used the output fetched directly to find the amount of the input

Aims to fix issue https://github.com/iotaledger/explorer/issues/324

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually on provided example.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
