### PR TITLE
Fix: Display correct immutable features type name.

### DIFF
--- a/client/src/app/components/stardust/Feature.tsx
+++ b/client/src/app/components/stardust/Feature.tsx
@@ -33,7 +33,7 @@ class FeatureBlock extends AsyncComponent<FeatureProps, FeatureState> {
      */
     public render(): ReactNode {
         const isExpanded = this.state.isExpanded;
-        const { feature } = this.props;
+        const { feature, isImmutable } = this.props;
 
         return (
             <div className="feature-block">
@@ -47,7 +47,7 @@ class FeatureBlock extends AsyncComponent<FeatureProps, FeatureState> {
                         <DropdownIcon />
                     </div>
                     <div className="card--label">
-                        {NameHelper.getFeatureTypeName(feature.type)}
+                        {NameHelper.getFeatureTypeName(feature.type, isImmutable)}
                     </div>
                 </div>
                 {isExpanded && (

--- a/client/src/app/components/stardust/FeatureProps.tsx
+++ b/client/src/app/components/stardust/FeatureProps.tsx
@@ -10,4 +10,9 @@ export interface FeatureProps {
      * Is the feature pre-expanded.
      */
     isPreExpanded?: boolean;
+
+    /**
+     * Is the feature immutable.
+     */
+    isImmutable: boolean;
 }

--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -233,7 +233,12 @@ class Output extends Component<OutputProps, OutputState> {
                                 />
                             ))}
                             {output.features?.map((feature, idx) => (
-                                <Feature key={idx} feature={feature} isPreExpanded={isPreExpanded} />
+                                <Feature
+                                    key={idx}
+                                    feature={feature}
+                                    isPreExpanded={isPreExpanded}
+                                    isImmutable={false}
+                                />
                             ))}
                             {output.type !== BASIC_OUTPUT_TYPE && output.immutableFeatures && (
                                 <React.Fragment>
@@ -242,6 +247,7 @@ class Output extends Component<OutputProps, OutputState> {
                                             key={idx}
                                             feature={immutableFeature}
                                             isPreExpanded={isPreExpanded}
+                                            isImmutable={true}
                                         />
                                     ))}
                                 </React.Fragment>

--- a/client/src/helpers/stardust/nameHelper.ts
+++ b/client/src/helpers/stardust/nameHelper.ts
@@ -90,17 +90,23 @@ export class NameHelper {
     /**
      * Get the name for the feature type.
      * @param type The type to get the name for.
+     * @param isImmutable Is the feature immutable.
      * @returns The feature type name.
      */
-    public static getFeatureTypeName(type: number): string {
+    public static getFeatureTypeName(type: number, isImmutable: boolean): string {
+        let name: string = "";
         if (type === SENDER_FEATURE_TYPE) {
-            return "Sender Feature";
+            name = "Sender";
         } else if (type === ISSUER_FEATURE_TYPE) {
-            return "Issuer Feature";
+            name = "Issuer";
         } else if (type === METADATA_FEATURE_TYPE) {
-            return "Metadata Feature";
+            name = "Metadata";
         } else if (type === TAG_FEATURE_TYPE) {
-            return "Tag Feature";
+            name = "Tag";
+        }
+
+        if (name) {
+            return isImmutable ? `Immutable ${name}` : name;
         }
         return "Unknown Feature";
     }


### PR DESCRIPTION
# Description of change

- Display immutable features type name correctly.
- Remove `Feature` string from `features` type name.

Aims to fix https://github.com/iotaledger/explorer/issues/376

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The change should be visible on the output page of Alias, Foundry or Nft output type.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
