### PR TITLE
added timestamp to metadata in deployment workflows

### DIFF
--- a/.github/workflows/client-shimmer-prod.yaml
+++ b/.github/workflows/client-shimmer-prod.yaml
@@ -51,6 +51,7 @@ jobs:
         run: npm install -g npm@7
       - name: Client Deploy
         run: |
-          npx vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} --force -m githubCommitSha=${{ github.sha }} --build-env REACT_APP_CONFIG_ID=$CONFIG_ID
-          VERCEL_DEPLOYMENT_URL=$(npx vercel ls --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} -m githubCommitSha=${{ github.sha }} 2>&1 | grep $VERCEL_PROJECT_NAME | awk {'print $2'})
+          TS="$( date +%s )"
+          npx vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} --force -m githubCommitSha=${{ github.sha }}  -m timestamp=$TS --build-env REACT_APP_CONFIG_ID=$CONFIG_ID
+          VERCEL_DEPLOYMENT_URL=$(npx vercel ls --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} -m githubCommitSha=${{ github.sha }} -m timestamp=$TS 2>&1 | grep $VERCEL_PROJECT_NAME | awk {'print $2'})
           # npx vercel alias --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} $VERCEL_DEPLOYMENT_URL $VERCEL_DOMAIN

--- a/.github/workflows/client-shimmer-prod.yaml
+++ b/.github/workflows/client-shimmer-prod.yaml
@@ -54,4 +54,4 @@ jobs:
           TS="$( date +%s )"
           npx vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} --force -m githubCommitSha=${{ github.sha }}  -m timestamp=$TS --build-env REACT_APP_CONFIG_ID=$CONFIG_ID
           VERCEL_DEPLOYMENT_URL=$(npx vercel ls --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} -m githubCommitSha=${{ github.sha }} -m timestamp=$TS 2>&1 | grep $VERCEL_PROJECT_NAME | awk {'print $2'})
-          # npx vercel alias --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} $VERCEL_DEPLOYMENT_URL $VERCEL_DOMAIN
+          npx vercel alias --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} $VERCEL_DEPLOYMENT_URL $VERCEL_DOMAIN

--- a/.github/workflows/client-shimmer-staging.yaml
+++ b/.github/workflows/client-shimmer-staging.yaml
@@ -51,6 +51,7 @@ jobs:
         run: npm install -g npm@7
       - name: Client Deploy
         run: |
-          npx vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} --force -m githubCommitSha=${{ github.sha }} --build-env REACT_APP_CONFIG_ID=$CONFIG_ID
-          VERCEL_DEPLOYMENT_URL=$(npx vercel ls --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} -m githubCommitSha=${{ github.sha }} 2>&1 | grep $VERCEL_PROJECT_NAME | awk {'print $2'})
+          TS="$( date +%s )"
+          npx vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} --force -m githubCommitSha=${{ github.sha }} -m timestamp=$TS --build-env REACT_APP_CONFIG_ID=$CONFIG_ID
+          VERCEL_DEPLOYMENT_URL=$(npx vercel ls --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} -m githubCommitSha=${{ github.sha }}  -m timestamp=$TS 2>&1 | grep $VERCEL_PROJECT_NAME | awk {'print $2'})
           npx vercel alias --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_SCOPE }} $VERCEL_DEPLOYMENT_URL $VERCEL_DOMAIN


### PR DESCRIPTION
adding a timestamp to the metadata prevents listing multiple deployments with the same github commit because the timestamp is unique