### PR TITLE
Fix: Improvements for Transaction History

### DIFF
--- a/client/src/app/components/stardust/AssociatedOutputsTable.scss
+++ b/client/src/app/components/stardust/AssociatedOutputsTable.scss
@@ -131,6 +131,10 @@
             .found-in, .date-created {
                 color: $gray-6;
             }
+
+            .date-created {
+                font-family: $ibm-plex-mono;
+            }
         }
 
         .card {
@@ -138,6 +142,10 @@
                 .value {
                     color: $gray-6;
                 }
+            }
+
+            .date-created .value {
+                font-family: $ibm-plex-mono;
             }
         }
 

--- a/client/src/app/components/stardust/history/TransactionCard.tsx
+++ b/client/src/app/components/stardust/history/TransactionCard.tsx
@@ -8,10 +8,11 @@ import NetworkContext from "../../../context/NetworkContext";
 import { ITransactionEntryProps } from "./TransactionEntryProps";
 
 const TransactionCard: React.FC<ITransactionEntryProps> = (
-    { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
+    { outputId, transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
-    const transactionIdShort = `${transactionId.slice(0, 19)}....${transactionId.slice(-19)}`
+    const outputIdShort = `${outputId.slice(0, 11)}....${outputId.slice(-11)}`;
+    const transactionIdShort = `${transactionId.slice(0, 11)}....${transactionId.slice(-11)}`;
     const ago = moment(date * 1000).fromNow();
 
     const valueView = (
@@ -29,6 +30,16 @@ const TransactionCard: React.FC<ITransactionEntryProps> = (
                 <div className="card--value">
                     <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
                         {transactionIdShort}
+                    </Link>
+                </div>
+            </div>
+            <div className="field">
+                <div className="label">
+                    Output Id
+                </div>
+                <div className="card--value">
+                    <Link to={`/${network}/output/${outputId}`} className="margin-r-t">
+                        {outputIdShort}
                     </Link>
                 </div>
             </div>

--- a/client/src/app/components/stardust/history/TransactionCard.tsx
+++ b/client/src/app/components/stardust/history/TransactionCard.tsx
@@ -7,7 +7,7 @@ import NetworkContext from "../../../context/NetworkContext";
 import { ITransactionEntryProps } from "./TransactionEntryProps";
 
 const TransactionCard: React.FC<ITransactionEntryProps> = (
-    { blockId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
+    { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
 
@@ -21,11 +21,11 @@ const TransactionCard: React.FC<ITransactionEntryProps> = (
         <div className="card">
             <div className="field">
                 <div className="label">
-                    Block Id
+                    Transaction Id
                 </div>
                 <div className="card--value">
-                    <Link to={`/${network}/block/${blockId}`} className="margin-r-t">
-                        {blockId}
+                    <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
+                        {transactionId}
                     </Link>
                 </div>
             </div>

--- a/client/src/app/components/stardust/history/TransactionCard.tsx
+++ b/client/src/app/components/stardust/history/TransactionCard.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import moment from "moment";
 import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { DateHelper } from "../../../../helpers/dateHelper";
@@ -10,6 +11,8 @@ const TransactionCard: React.FC<ITransactionEntryProps> = (
     { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
+    const transactionIdShort = `${transactionId.slice(0, 19)}....${transactionId.slice(-19)}`
+    const ago = moment(date * 1000).fromNow();
 
     const valueView = (
         <span className="pointer margin-r-5" onClick={() => setIsFormattedAmounts(!isFormattedAmounts)} >
@@ -25,7 +28,7 @@ const TransactionCard: React.FC<ITransactionEntryProps> = (
                 </div>
                 <div className="card--value">
                     <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
-                        {transactionId}
+                        {transactionIdShort}
                     </Link>
                 </div>
             </div>
@@ -34,7 +37,7 @@ const TransactionCard: React.FC<ITransactionEntryProps> = (
                     Date
                 </div>
                 <div className="card--value">
-                    {DateHelper.formatShort(date * 1000)}
+                    {`${DateHelper.formatShort(date * 1000)} (${ago})`}
                 </div>
             </div>
             <div className="field">

--- a/client/src/app/components/stardust/history/TransactionEntryProps.ts
+++ b/client/src/app/components/stardust/history/TransactionEntryProps.ts
@@ -1,5 +1,10 @@
 export interface ITransactionEntryProps {
     /**
+     * The output id.
+     */
+    outputId: string;
+
+    /**
      * The transaction id.
      */
     transactionId: string;
@@ -28,5 +33,11 @@ export interface ITransactionEntryProps {
      * The setter for formatted amounts toggle.
      */
     setIsFormattedAmounts: React.Dispatch<React.SetStateAction<boolean>>;
+
+    /**
+     * To colour the transaction row ligter/darker, alternating on
+     * unrelated transactions.
+     */
+    darkBackgroundRow?: boolean;
 }
 

--- a/client/src/app/components/stardust/history/TransactionEntryProps.ts
+++ b/client/src/app/components/stardust/history/TransactionEntryProps.ts
@@ -1,8 +1,8 @@
 export interface ITransactionEntryProps {
     /**
-     * The block id.
+     * The transaction id.
      */
-    blockId: string;
+    transactionId: string;
 
     /**
      * The date of the transaction.

--- a/client/src/app/components/stardust/history/TransactionHistory.scss
+++ b/client/src/app/components/stardust/history/TransactionHistory.scss
@@ -32,7 +32,7 @@
             }
 
             td {
-                &.block-id {
+                &.transaction-id {
                     @include font-size(14px);
                     color: var(--link-color);
                     font-family: $ibm-plex-mono;
@@ -43,7 +43,8 @@
                 }
 
                 &.date {
-                    @include font-size(16px);
+                    @include font-size(14px);
+                    font-family: $ibm-plex-mono;
                 }
 
                 &.amount {

--- a/client/src/app/components/stardust/history/TransactionHistory.scss
+++ b/client/src/app/components/stardust/history/TransactionHistory.scss
@@ -8,8 +8,7 @@
 
     .transaction-history--table {
         width: 100%;
-        border-spacing: 12px 24px;
-        border-collapse: separate;
+        border-spacing: 0 0;
 
         @include tablet-down {
             display: none;
@@ -18,13 +17,20 @@
         tr {
             @include font-size(14px);
 
+            border: 1px solid;
+            border-radius: 4px;
             color: $gray-7;
             font-family: $inter;
             letter-spacing: 0.5px;
 
+            &.dark {
+                background: $gray-1;
+            }
+
             th {
                 @include font-size(12px);
 
+                text-align: center!important;
                 color: $gray-6;
                 font-weight: 600;
                 text-align: left;
@@ -32,7 +38,10 @@
             }
 
             td {
-                &.transaction-id {
+                padding: 16px 0;
+                text-align: center;
+
+                &.transaction-id, &.output-id {
                     @include font-size(14px);
                     color: var(--link-color);
                     font-family: $ibm-plex-mono;
@@ -40,6 +49,12 @@
                     letter-spacing: 0.02em;
                     line-height: 20px;
                     word-break: break-all;
+                }
+
+                &.output-id .highlight {
+                    font-weight: 500;
+                    color: $gray-6;
+                    margin-left: 2px;
                 }
 
                 &.date {

--- a/client/src/app/components/stardust/history/TransactionHistory.tsx
+++ b/client/src/app/components/stardust/history/TransactionHistory.tsx
@@ -146,7 +146,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
             <table className="transaction-history--table">
                 <thead>
                     <tr>
-                        <th>Block Id</th>
+                        <th>Transaction Id</th>
                         <th>Date</th>
                         <th>Value</th>
                     </tr>
@@ -155,11 +155,21 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
                     {historyPage.length > 0 && (
                         historyPage.map((historyItem, idx) => {
                             const outputDetails = outputDetailsMap[historyItem.outputId];
+                            if (!outputDetails) {
+                                return null;
+                            }
+                            const transactionId = historyItem.isSpent ?
+                                outputDetails.metadata.transactionIdSpent :
+                                outputDetails.metadata.transactionId;
+
+                            if (!transactionId) {
+                                return null;
+                            }
 
                             return outputDetails ? (
                                 <React.Fragment key={idx}>
                                     <TransactionRow
-                                        blockId={outputDetails.metadata.blockId}
+                                        transactionId={transactionId}
                                         date={historyItem.milestoneTimestamp}
                                         value={Number(outputDetails.output.amount)}
                                         isSpent={historyItem.isSpent}
@@ -177,18 +187,27 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
                 {historyPage.length > 0 && (
                     historyPage.map((historyItem, idx) => {
                         const outputDetails = outputDetailsMap[historyItem.outputId];
+                        if (!outputDetails) {
+                            return null;
+                        }
+                        const transactionId = historyItem.isSpent ?
+                            outputDetails.metadata.transactionIdSpent :
+                            outputDetails.metadata.transactionId;
 
-                        return outputDetails ? (
-                            <React.Fragment key={idx}>
-                                <TransactionCard
-                                    blockId={outputDetails.metadata.blockId}
-                                    date={historyItem.milestoneTimestamp}
-                                    value={Number(outputDetails.output.amount)}
-                                    isSpent={historyItem.isSpent}
-                                    isFormattedAmounts={isFormattedAmounts}
-                                    setIsFormattedAmounts={setIsFormattedAmounts}
-                                />
-                            </React.Fragment>) : null;
+                        if (!transactionId) {
+                            return null;
+                        }
+
+                        return (<React.Fragment key={idx}>
+                            <TransactionCard
+                                transactionId={transactionId}
+                                date={historyItem.milestoneTimestamp}
+                                value={Number(outputDetails.output.amount)}
+                                isSpent={historyItem.isSpent}
+                                isFormattedAmounts={isFormattedAmounts}
+                                setIsFormattedAmounts={setIsFormattedAmounts}
+                            />
+                        </React.Fragment>);
                     })
                 )}
             </div>

--- a/client/src/app/components/stardust/history/TransactionHistory.tsx
+++ b/client/src/app/components/stardust/history/TransactionHistory.tsx
@@ -115,7 +115,14 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
     useEffect(() => {
         const from = (currentPageNumber - 1) * PAGE_SIZE;
         const to = from + PAGE_SIZE;
-        const page = history?.slice(from, to);
+        const page = history?.slice(from, to).sort((a, b) => {
+            // Ensure that entries with equal timestamp, but different isSpent,
+            // have the spending before the depositing
+            if (a.milestoneTimestamp === b.milestoneTimestamp && a.isSpent !== b.isSpent) {
+                return !a.isSpent ? -1 : 1;
+            }
+            return 1;
+        });
 
         if (mounted.current) {
             setHistoryPage(page);

--- a/client/src/app/components/stardust/history/TransactionHistory.tsx
+++ b/client/src/app/components/stardust/history/TransactionHistory.tsx
@@ -25,7 +25,7 @@ interface IOutputDetailsMap {
 }
 
 const PAGE_SIZE: number = 10;
-const SORT: string = "asc";
+const SORT: string = "newest";
 
 /**
  * Component which will display transaction history.

--- a/client/src/app/components/stardust/history/TransactionHistory.tsx
+++ b/client/src/app/components/stardust/history/TransactionHistory.tsx
@@ -137,6 +137,8 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
         }
     };
 
+    let isDarkBackgroundRow = false;
+
     return (totalCount > 0 ? (
         <div className="section transaction-history--section">
             <div className="section--header row space-between">
@@ -154,6 +156,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
                 <thead>
                     <tr>
                         <th>Transaction Id</th>
+                        <th>Output Id</th>
                         <th>Date</th>
                         <th>Value</th>
                     </tr>
@@ -173,15 +176,32 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
                                 return null;
                             }
 
+                            // rotate row background colour for different transaction ids
+                            if (idx > 0) {
+                                const previousItemDetails = outputDetailsMap[historyPage[idx - 1].outputId];
+                                const previousSpent = historyPage[idx - 1].isSpent;
+                                if (previousItemDetails) {
+                                    const previousTransactionId = previousSpent ?
+                                        previousItemDetails.metadata.transactionIdSpent :
+                                        previousItemDetails.metadata.transactionId;
+
+                                    if (transactionId !== previousTransactionId) {
+                                        isDarkBackgroundRow = !isDarkBackgroundRow;
+                                    }
+                                }
+                            }
+
                             return outputDetails ? (
                                 <React.Fragment key={idx}>
                                     <TransactionRow
+                                        outputId={historyItem.outputId}
                                         transactionId={transactionId}
                                         date={historyItem.milestoneTimestamp}
                                         value={Number(outputDetails.output.amount)}
                                         isSpent={historyItem.isSpent}
                                         isFormattedAmounts={isFormattedAmounts}
                                         setIsFormattedAmounts={setIsFormattedAmounts}
+                                        darkBackgroundRow={isDarkBackgroundRow}
                                     />
                                 </React.Fragment>) : null;
                         })
@@ -205,16 +225,19 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({ network, addres
                             return null;
                         }
 
-                        return (<React.Fragment key={idx}>
-                            <TransactionCard
-                                transactionId={transactionId}
-                                date={historyItem.milestoneTimestamp}
-                                value={Number(outputDetails.output.amount)}
-                                isSpent={historyItem.isSpent}
-                                isFormattedAmounts={isFormattedAmounts}
-                                setIsFormattedAmounts={setIsFormattedAmounts}
-                            />
-                        </React.Fragment>);
+                        return (
+                            <React.Fragment key={idx}>
+                                <TransactionCard
+                                    outputId={historyItem.outputId}
+                                    transactionId={transactionId}
+                                    date={historyItem.milestoneTimestamp}
+                                    value={Number(outputDetails.output.amount)}
+                                    isSpent={historyItem.isSpent}
+                                    isFormattedAmounts={isFormattedAmounts}
+                                    setIsFormattedAmounts={setIsFormattedAmounts}
+                                />
+                            </React.Fragment>
+                        );
                     })
                 )}
             </div>

--- a/client/src/app/components/stardust/history/TransactionRow.tsx
+++ b/client/src/app/components/stardust/history/TransactionRow.tsx
@@ -8,10 +8,12 @@ import NetworkContext from "../../../context/NetworkContext";
 import { ITransactionEntryProps } from "./TransactionEntryProps";
 
 const TransactionRow: React.FC<ITransactionEntryProps> = (
-    { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
+    { outputId, transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts, darkBackgroundRow }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
-    const transactionIdShort = `${transactionId.slice(0, 19)}....${transactionId.slice(-19)}`
+    const outputIdTransactionShort = `${outputId.slice(0, 11)}....${outputId.slice(-11, -4)}`;
+    const outputIdIndex = outputId.slice(-4);
+    const transactionIdShort = `${transactionId.slice(0, 11)}....${transactionId.slice(-11)}`;
     const ago = moment(date * 1000).fromNow();
 
     const valueView = (
@@ -21,10 +23,15 @@ const TransactionRow: React.FC<ITransactionEntryProps> = (
     );
 
     return (
-        <tr>
+        <tr className={darkBackgroundRow ? "dark" : ""}>
             <td className="transaction-id">
                 <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
                     {transactionIdShort}
+                </Link>
+            </td>
+            <td className="output-id">
+                <Link to={`/${network}/output/${outputId}`} className="margin-r-t">
+                    <span>{outputIdTransactionShort}</span> <span className="highlight">{outputIdIndex}</span>
                 </Link>
             </td>
             <td className="date">{`${DateHelper.formatShort(date * 1000)} (${ago})`}</td>

--- a/client/src/app/components/stardust/history/TransactionRow.tsx
+++ b/client/src/app/components/stardust/history/TransactionRow.tsx
@@ -7,7 +7,7 @@ import NetworkContext from "../../../context/NetworkContext";
 import { ITransactionEntryProps } from "./TransactionEntryProps";
 
 const TransactionRow: React.FC<ITransactionEntryProps> = (
-    { blockId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
+    { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
 
@@ -20,8 +20,8 @@ const TransactionRow: React.FC<ITransactionEntryProps> = (
     return (
         <tr>
             <td className="block-id">
-                <Link to={`/${network}/block/${blockId}`} className="margin-r-t">
-                    {blockId}
+                <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
+                    {transactionId}
                 </Link>
             </td>
             <td className="date">{DateHelper.formatShort(date * 1000)}</td>

--- a/client/src/app/components/stardust/history/TransactionRow.tsx
+++ b/client/src/app/components/stardust/history/TransactionRow.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import moment from "moment";
 import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { DateHelper } from "../../../../helpers/dateHelper";
@@ -10,6 +11,8 @@ const TransactionRow: React.FC<ITransactionEntryProps> = (
     { transactionId, date, value, isSpent, isFormattedAmounts, setIsFormattedAmounts }
 ) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
+    const transactionIdShort = `${transactionId.slice(0, 19)}....${transactionId.slice(-19)}`
+    const ago = moment(date * 1000).fromNow();
 
     const valueView = (
         <span className="pointer margin-r-5" onClick={() => setIsFormattedAmounts(!isFormattedAmounts)} >
@@ -19,12 +22,12 @@ const TransactionRow: React.FC<ITransactionEntryProps> = (
 
     return (
         <tr>
-            <td className="block-id">
+            <td className="transaction-id">
                 <Link to={`/${network}/transaction/${transactionId}`} className="margin-r-t">
-                    {transactionId}
+                    {transactionIdShort}
                 </Link>
             </td>
-            <td className="date">{DateHelper.formatShort(date * 1000)}</td>
+            <td className="date">{`${DateHelper.formatShort(date * 1000)} (${ago})`}</td>
             <td className={classNames("amount", { "negative": isSpent })}>{valueView}</td>
         </tr>
     );


### PR DESCRIPTION
# Description of change

Improvements for Transaction History based on discussions and testnet feedback
- Instead of blockId, now we show OutputId and TransactionId
- Entries from output that is "spending" will now display the transactionId where the output was spent, for clarity
- Date column now also shows "X time ago" info
- Rows in the table have alternated background colour, except if they have the same transactionid. This way the related transactions are better visually grouped
- Transaction sort is fixed to "newest" first now

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Visually
## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
