### PR TITLE
Fix: Format balance to two decimal places without rounding off

### DIFF
--- a/client/src/helpers/stardust/valueFormatHelper.ts
+++ b/client/src/helpers/stardust/valueFormatHelper.ts
@@ -18,7 +18,7 @@ export function formatAmount(
         return `${value} ${tokenInfo.subunit ? tokenInfo.subunit : tokenInfo.unit}`;
     }
     const baseTokenValue = value / Math.pow(10, tokenInfo.decimals);
-    const amount = tokenInfo.useMetricPrefix && baseTokenValue
+    const amount = tokenInfo.useMetricPrefix
         ? UnitsHelper.formatBest(baseTokenValue)
         : `${toFixedNoRound(baseTokenValue, decimalPlaces)} `;
 

--- a/client/src/helpers/stardust/valueFormatHelper.ts
+++ b/client/src/helpers/stardust/valueFormatHelper.ts
@@ -18,9 +18,20 @@ export function formatAmount(
         return `${value} ${tokenInfo.subunit ? tokenInfo.subunit : tokenInfo.unit}`;
     }
     const baseTokenValue = value / Math.pow(10, tokenInfo.decimals);
-    const amount = tokenInfo.useMetricPrefix
+    const amount = tokenInfo.useMetricPrefix && baseTokenValue
         ? UnitsHelper.formatBest(baseTokenValue)
-        : `${Number.parseFloat(baseTokenValue.toFixed(decimalPlaces))} `;
+        : `${toFixedNoRound(baseTokenValue, decimalPlaces)} `;
 
         return `${amount}${tokenInfo.unit}`;
+}
+
+/**
+ * Format amount to two decimal places without rounding off.
+ * @param value The raw amount to format.
+ * @param precision The decimal places to show.
+ * @returns The formatted amount.
+ */
+function toFixedNoRound(value: number, precision: number = 2) {
+    const factor = Math.pow(10, precision);
+    return Math.floor(value * factor) / factor;
 }


### PR DESCRIPTION
# Description of change

Truncate balance to two decimal places without rounding off so that the user can see the actual balance.

Aims to fix https://github.com/iotaledger/explorer/issues/431


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

TransactionId = `0xc358097109e37fa268024f66090b1551d18bc7e99041135d494484930fa8dd29`

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
