### PR TITLE
Fix: Expand only the clicked native token

### DIFF
--- a/client/src/app/components/stardust/NativeToken.tsx
+++ b/client/src/app/components/stardust/NativeToken.tsx
@@ -1,0 +1,71 @@
+import classNames from "classnames";
+import React, { ReactNode } from "react";
+import AsyncComponent from "../AsyncComponent";
+import { ReactComponent as DropdownIcon } from "./../../../assets/dropdown-arrow.svg";
+import { NativeTokenProps } from "./NativeTokenProps";
+import { NativeTokenState } from "./NativeTokenState";
+
+/**
+ * Component which will display a native token.
+ */
+class NativeToken extends AsyncComponent<NativeTokenProps, NativeTokenState> {
+    constructor(props: NativeTokenProps) {
+        super(props);
+
+        this.state = {
+            isExpanded: this.props.isPreExpanded ?? false
+        };
+    }
+
+    /**
+     * The component mounted.
+     */
+     public async componentDidMount(): Promise<void> {
+        super.componentDidMount();
+    }
+
+    /**
+     * Render the component.
+     * @returns The node to render.
+     */
+    public render(): ReactNode {
+        const { isExpanded } = this.state;
+        const { tokenId, amount } = this.props;
+
+        return (
+            <div className="native-token">
+                <div
+                    className="card--content__input card--value row middle"
+                    onClick={() => this.setState({ isExpanded: !isExpanded })}
+                >
+                    <div className={classNames("margin-r-t", "card--content--dropdown",
+                        { opened: isExpanded })}
+                    >
+                        <DropdownIcon />
+                    </div>
+                    <div className="card--label">
+                        Native token
+                    </div>
+                </div>
+                {isExpanded && (
+                <div className="margin-l-t">
+                    <div className="card--label">
+                        Token id:
+                    </div>
+                    <div className="card--value row">
+                        {tokenId}
+                    </div>
+                    <div className="card--label">
+                        Amount:
+                    </div>
+                    <div className="card--value row">
+                        {Number(amount)}
+                    </div>
+                </div>
+                )}
+            </div>
+        );
+    }
+}
+
+export default NativeToken;

--- a/client/src/app/components/stardust/NativeTokenProps.ts
+++ b/client/src/app/components/stardust/NativeTokenProps.ts
@@ -1,0 +1,16 @@
+export interface NativeTokenProps {
+    /**
+     * The token id.
+     */
+    tokenId: string;
+
+    /**
+     * The amount of native token.
+     */
+    amount: number;
+
+    /**
+     * Is the native token pre-expanded.
+     */
+    isPreExpanded?: boolean;
+}

--- a/client/src/app/components/stardust/NativeTokenState.ts
+++ b/client/src/app/components/stardust/NativeTokenState.ts
@@ -1,0 +1,6 @@
+export interface NativeTokenState {
+    /**
+     * Is expanded.
+     */
+    isExpanded: boolean;
+}

--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -18,6 +18,7 @@ import CopyButton from "../CopyButton";
 import DataToggle from "../DataToggle";
 import { ReactComponent as DropdownIcon } from "./../../../assets/dropdown-arrow.svg";
 import Feature from "./Feature";
+import NativeToken from "./NativeToken";
 import { OutputProps } from "./OutputProps";
 import { OutputState } from "./OutputState";
 import UnlockCondition from "./UnlockCondition";
@@ -40,7 +41,6 @@ class Output extends Component<OutputProps, OutputState> {
         super(props);
 
         this.state = {
-            showNativeToken: this.props.isPreExpanded ?? false,
             isExpanded: this.props.isPreExpanded ?? false,
             isFormattedBalance: true
         };
@@ -52,7 +52,7 @@ class Output extends Component<OutputProps, OutputState> {
      */
     public render(): ReactNode {
         const { outputId, output, amount, showCopyAmount, network, isPreExpanded } = this.props;
-        const { showNativeToken, isExpanded, isFormattedBalance } = this.state;
+        const { isExpanded, isFormattedBalance } = this.state;
 
         const aliasOrNftBech32 = this.buildAddressForAliasOrNft();
         const foundryId = this.buildFoundyId();
@@ -261,39 +261,12 @@ class Output extends Component<OutputProps, OutputState> {
                                 </React.Fragment>
                             )}
                             {output.nativeTokens?.map((token, idx) => (
-                                <React.Fragment key={idx}>
-                                    <div className="native-token">
-                                        <div
-                                            className="card--content__input card--value row middle"
-                                            onClick={() => this.setState({ showNativeToken: !showNativeToken })}
-                                        >
-                                            <div className={classNames("margin-r-t", "card--content--dropdown",
-                                                                       { opened: showNativeToken })}
-                                            >
-                                                <DropdownIcon />
-                                            </div>
-                                            <div className="card--label">
-                                                Native token
-                                            </div>
-                                        </div>
-                                        {showNativeToken && (
-                                        <div className="margin-l-t">
-                                            <div className="card--label">
-                                                Token id:
-                                            </div>
-                                            <div className="card--value row">
-                                                {token.id}
-                                            </div>
-                                            <div className="card--label">
-                                                Amount:
-                                            </div>
-                                            <div className="card--value row">
-                                                {Number(token.amount)}
-                                            </div>
-                                        </div>
-                                        )}
-                                    </div>
-                                </React.Fragment>
+                                <NativeToken
+                                    key={idx}
+                                    tokenId={token.id}
+                                    amount={Number(token.amount)}
+                                    isPreExpanded={isPreExpanded}
+                                />
                             ))}
                         </React.Fragment>
                         )}

--- a/client/src/app/components/stardust/OutputState.tsx
+++ b/client/src/app/components/stardust/OutputState.tsx
@@ -1,9 +1,5 @@
 export interface OutputState {
     /**
-     * Shows details of the native token.
-     */
-    showNativeToken: boolean;
-    /**
      * Show output details.
      */
     isExpanded: boolean;


### PR DESCRIPTION
# Description of change

- Created a separate native token component so that it cannot expand all the native tokens at once.

Aims to fix https://github.com/iotaledger/explorer/issues/430

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

transactionId = `0x5ad9932fedd598ac76393f49e2296c662abf57c70df4bf67427f76d1f5d27d49`

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
