### PR TITLE
Fix: Make "spent in transaction" a link and copiable in OutputPage

### DIFF
--- a/client/src/app/routes/stardust/Block.tsx
+++ b/client/src/app/routes/stardust/Block.tsx
@@ -347,7 +347,7 @@ class Block extends AsyncComponent<RouteComponentProps<BlockProps>, BlockState> 
                                                         Parents
                                                     </div>
                                                     {this.state.metadata.parents.map((parent, idx) => (
-                                                        <div key={idx} className="value code link">
+                                                        <div key={idx} style={{marginTop: "8px"}} className="value code link">
                                                             <Link
                                                                 to={`/${network}/block/${parent}`}
                                                                 className="margin-r-t"

--- a/client/src/app/routes/stardust/OutputPage.tsx
+++ b/client/src/app/routes/stardust/OutputPage.tsx
@@ -158,10 +158,18 @@ const OutputPage: React.FC<RouteComponentProps<OutputPageProps>> = (
                                 <div className="label">
                                     Spent in transaction with ID
                                 </div>
-                                <div className="value code row middle">
-                                    <span className="margin-r-t">
+                                <div className="value code row middle highlight">
+                                    <Link
+                                        to={`/${network}/transaction/${transactionIdSpent}`}
+                                        className="margin-r-t"
+                                    >
                                         {transactionIdSpent}
-                                    </span>
+                                    </Link>
+                                    <CopyButton
+                                        onClick={() => ClipboardHelper.copy(transactionIdSpent)}
+                                        buttonType="copy"
+                                        labelPosition="bottom"
+                                    />
                                 </div>
                             </div>
                         )}

--- a/client/src/app/routes/stardust/TransactionPage.tsx
+++ b/client/src/app/routes/stardust/TransactionPage.tsx
@@ -288,7 +288,7 @@ class TransactionPage extends AsyncComponent<RouteComponentProps<TransactionPage
                                                     Parents
                                                 </div>
                                                 {metadata.parents.map((parent, idx) => (
-                                                    <div key={idx} style={{marginTop: "8px"}} className="parents value code link">
+                                                    <div key={idx} style={{marginTop: "8px"}} className="value code link">
                                                         <Link
                                                             to={`/${network}/block/${parent}`}
                                                             className="margin-r-t"

--- a/client/src/app/routes/stardust/TransactionPage.tsx
+++ b/client/src/app/routes/stardust/TransactionPage.tsx
@@ -288,7 +288,7 @@ class TransactionPage extends AsyncComponent<RouteComponentProps<TransactionPage
                                                     Parents
                                                 </div>
                                                 {metadata.parents.map((parent, idx) => (
-                                                    <div key={idx} className="value code link">
+                                                    <div key={idx} style={{marginTop: "8px"}} className="parents value code link">
                                                         <Link
                                                             to={`/${network}/block/${parent}`}
                                                             className="margin-r-t"


### PR DESCRIPTION
# Description of change

- Added redirection to transaction page from `Spent in transaction with ID` on Output page.
- Highlight `Spent in transaction with ID` value.
- Added copy button.

Aims to complete https://github.com/iotaledger/explorer/issues/433

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Visit output page that has already been spent.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
