### PR TITLE
Fix: Fix market cap off by factor of 10

### DIFF
--- a/client/src/services/currencyService.ts
+++ b/client/src/services/currencyService.ts
@@ -492,11 +492,10 @@ export class CurrencyService {
             { value: 1e15, symbol: "P" },
             { value: 1e18, symbol: "E" }
         ];
-        const regex = /\.0+$|(\.\d*[1-9])0+$/;
         const item = units.slice().reverse()
             .find(unit => value >= unit.value);
 
-        return item ? (value / item.value).toFixed(digits).replace(regex, "1") + item.symbol : "0";
+        return item ? (value / item.value).toFixed(digits) + item.symbol : "0";
     }
 
     /**


### PR DESCRIPTION
# Description of change

- Remove a confusing regex replace that was causing the issue

I couldn't really understand the point of this "regex + replace" nor why it was in the code.
To me it seams like replacing the point and fraction with a "1" just makes the value incorrect.

What this regex was doing is something like:
`55.00` -> `551`
or 
`55.80` -> `551`

Issue introduced here https://github.com/iotaledger/explorer/pull/103

Aims to fix https://github.com/iotaledger/explorer/issues/445

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually in code, as it is hard to get the right value to trigger this case.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
