### PR TITLE
Fix: Include ALIAS and NFT unlock types when computing block signatures

### DIFF
--- a/client/src/helpers/stardust/transactionsHelper.ts
+++ b/client/src/helpers/stardust/transactionsHelper.ts
@@ -3,7 +3,7 @@ import { Blake2b } from "@iota/crypto.js-stardust";
 import {
     BASIC_OUTPUT_TYPE, IAddressUnlockCondition, IStateControllerAddressUnlockCondition,
     IGovernorAddressUnlockCondition, IBlock,
-    ISignatureUnlock, REFERENCE_UNLOCK_TYPE, SIGNATURE_UNLOCK_TYPE,
+    ISignatureUnlock, SIGNATURE_UNLOCK_TYPE,
     TRANSACTION_PAYLOAD_TYPE, ADDRESS_UNLOCK_CONDITION_TYPE, ITransactionPayload,
     IBasicOutput, UnlockConditionTypes, ITreasuryOutput, IAliasOutput, INftOutput, IFoundryOutput,
     TREASURY_OUTPUT_TYPE, STATE_CONTROLLER_ADDRESS_UNLOCK_CONDITION_TYPE,
@@ -48,7 +48,7 @@ export class TransactionsHelper {
                 const unlock = payload.unlocks[i];
                 if (unlock.type === SIGNATURE_UNLOCK_TYPE) {
                     unlocks.push(unlock);
-                } else if (unlock.type === REFERENCE_UNLOCK_TYPE) {
+                } else {
                     let refUnlockIdx = i;
                     let signatureUnlock: ISignatureUnlock;
                     // unlock references can be transitive,


### PR DESCRIPTION
# Description of change

- Previously in `transactionHelper.ts` where we compute `unlocks` we only had the functionality to compute unlocks for `SIGNATURE_UNLOCK_TYPE` and `REFERENCE_UNLOCK_TYPE`. Now, we added the functionality for `ALIAS_UNLOCK_TYPE` and `NFT_UNLOCK_TYPE`

Aims to fix https://github.com/iotaledger/explorer/issues/444

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

**Block Id** = `0x80b3df2fdc2696db2caca49ba6cab2edc32cc7af56fac67c9dba831a09779d7b`.
You will now see the metadata is loading.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
