### PR TITLE
Fix: Decouple seconds since last milestone from milestone timestamp in FeedInfo

### DIFF
--- a/client/src/app/components/FeedInfo.tsx
+++ b/client/src/app/components/FeedInfo.tsx
@@ -5,30 +5,21 @@ import "./FeedInfo.scss";
 export interface FeedInfoProps {
     milestoneIndex?: number;
     frequencyTarget?: number;
-    milestoneTimestamp?: number;
 }
 
-const FeedInfo: React.FC<FeedInfoProps> = ({ milestoneIndex, milestoneTimestamp, frequencyTarget }) => {
+const FeedInfo: React.FC<FeedInfoProps> = ({ milestoneIndex, frequencyTarget }) => {
     const [from, setFrom] = useState<moment.Moment | undefined>();
     const [seconds, setSeconds] = useState<number | undefined>();
 
     useEffect(() => {
-        const now = moment();
-        // This is needed because clock seconds might not be synced around the world.
-        setFrom(
-            now.isBefore(moment(milestoneTimestamp)) ?
-                now :
-                moment(milestoneTimestamp)
-        );
-    }, [milestoneIndex, milestoneTimestamp]);
+        setFrom(moment());
+    }, [milestoneIndex]);
 
     useEffect(() => {
         const interval = setInterval(() => {
-            if (milestoneTimestamp !== 0) {
-                const to = moment();
-                const updatedSeconds = to.diff(from, "seconds", true);
-                setSeconds(updatedSeconds);
-            }
+            const to = moment();
+            const updatedSeconds = to.diff(from, "seconds", true);
+            setSeconds(updatedSeconds);
         }, 80);
 
         return () => {
@@ -56,8 +47,7 @@ const FeedInfo: React.FC<FeedInfoProps> = ({ milestoneIndex, milestoneTimestamp,
 
 FeedInfo.defaultProps = {
     frequencyTarget: undefined,
-    milestoneIndex: undefined,
-    milestoneTimestamp: undefined
+    milestoneIndex: undefined
 };
 
 export default FeedInfo;

--- a/client/src/app/components/FeedsState.ts
+++ b/client/src/app/components/FeedsState.ts
@@ -22,11 +22,6 @@ export interface FeedsState extends CurrencyState {
     latestMilestoneIndex?: number;
 
     /**
-     * The latest milestone timestamp.
-     */
-    latestMilestoneTimestamp?: number;
-
-    /**
      * The items per second.
      */
     itemsPerSecondHistory: number[];

--- a/client/src/app/components/chrysalis/Feeds.tsx
+++ b/client/src/app/components/chrysalis/Feeds.tsx
@@ -111,30 +111,22 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
      * @param newItems The updated items.
      */
     protected itemsUpdated(newItems: IFeedItem[]): void {
-        const isLatestMilesontFeedInfoEnabled = this._networkConfig &&
+        const isLatestMilesoneFeedInfoEnabled = this._networkConfig &&
             this._networkConfig.network !== LEGACY_MAINNET &&
             this._networkConfig.network !== CUSTOM;
 
-        if (isLatestMilesontFeedInfoEnabled && newItems) {
+        if (isLatestMilesoneFeedInfoEnabled && newItems) {
             const milestones = newItems.filter(i => i.payloadType === "MS");
             let newIndex;
-            let newTimestamp;
             for (const ms of milestones) {
                 const index: number | undefined = ms.properties?.index as number;
                 const currentIndex = this.state.latestMilestoneIndex;
                 if (index && currentIndex !== undefined && index > currentIndex) {
-                    const timestamp: number | undefined = ms.properties?.timestamp as number;
-                    if (timestamp) {
-                        newIndex = index;
-                        newTimestamp = timestamp;
-                    }
+                    newIndex = index;
                 }
             }
-            if (newIndex && newTimestamp) {
-                this.setState({
-                    latestMilestoneIndex: newIndex,
-                    latestMilestoneTimestamp: newTimestamp * 1000
-                });
+            if (newIndex) {
+                this.setState({ latestMilestoneIndex: newIndex });
             }
         }
     }
@@ -229,8 +221,6 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
                         ? `${confirmedRate.toFixed(2)}%` : "--",
                     latestMilestoneIndex: this.state.latestMilestoneIndex ? this.state.latestMilestoneIndex :
                         ips.latestMilestoneIndex,
-                    latestMilestoneTimestamp: this.state.latestMilestoneTimestamp ?
-                        this.state.latestMilestoneTimestamp : ips.latestMilestoneIndexTime,
                     // Increase values by +100 to add more area under the graph
                     itemsPerSecondHistory: (ips.itemsPerSecondHistory ?? []).map(v => v + 100)
                 });

--- a/client/src/app/components/chrysalis/Feeds.tsx
+++ b/client/src/app/components/chrysalis/Feeds.tsx
@@ -111,11 +111,11 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
      * @param newItems The updated items.
      */
     protected itemsUpdated(newItems: IFeedItem[]): void {
-        const isLatestMilesoneFeedInfoEnabled = this._networkConfig &&
+        const isLatestMilestoneFeedInfoEnabled = this._networkConfig &&
             this._networkConfig.network !== LEGACY_MAINNET &&
             this._networkConfig.network !== CUSTOM;
 
-        if (isLatestMilesoneFeedInfoEnabled && newItems) {
+        if (isLatestMilestoneFeedInfoEnabled && newItems) {
             const milestones = newItems.filter(i => i.payloadType === "MS");
             let newIndex;
             for (const ms of milestones) {

--- a/client/src/app/components/stardust/Feeds.tsx
+++ b/client/src/app/components/stardust/Feeds.tsx
@@ -113,23 +113,15 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
         if (newItems) {
             const milestones = newItems.filter(i => i.payloadType === "MS");
             let newIndex;
-            let newTimestamp;
             for (const ms of milestones) {
                 const index: number | undefined = ms.properties?.index as number;
                 const currentIndex = this.state.latestMilestoneIndex;
                 if (index && currentIndex !== undefined && index > currentIndex) {
-                    const timestamp: number | undefined = ms.properties?.timestamp as number;
-                    if (timestamp) {
-                        newIndex = index;
-                        newTimestamp = timestamp;
-                    }
+                    newIndex = index;
                 }
             }
-            if (newIndex && newTimestamp) {
-                this.setState({
-                    latestMilestoneIndex: newIndex,
-                    latestMilestoneTimestamp: newTimestamp * 1000
-                });
+            if (newIndex) {
+                this.setState({ latestMilestoneIndex: newIndex });
             }
         }
     }
@@ -224,8 +216,6 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
                         ? `${confirmedRate.toFixed(2)}%` : "--",
                     latestMilestoneIndex: this.state.latestMilestoneIndex ? this.state.latestMilestoneIndex :
                         ips.latestMilestoneIndex,
-                    latestMilestoneTimestamp: this.state.latestMilestoneTimestamp ?
-                        this.state.latestMilestoneTimestamp : ips.latestMilestoneIndexTime,
                     // Increase values by +100 to add more area under the graph
                     itemsPerSecondHistory: (ips.itemsPerSecondHistory ?? []).map(v => v + 100)
                 });

--- a/client/src/app/routes/chrysalis/Landing.tsx
+++ b/client/src/app/routes/chrysalis/Landing.tsx
@@ -93,7 +93,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
      * @returns The node to render.
      */
     public render(): ReactNode {
-        const isLatestMilesoneFeedInfoEnabled = this._networkConfig &&
+        const isLatestMilestoneFeedInfoEnabled = this._networkConfig &&
             this._networkConfig.network !== LEGACY_MAINNET &&
             this._networkConfig.network !== CUSTOM;
 
@@ -256,7 +256,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                             )}
                                         </div>
                                     </div>
-                                    {isLatestMilesoneFeedInfoEnabled && (
+                                    {isLatestMilestoneFeedInfoEnabled && (
                                         <FeedInfo
                                             milestoneIndex={this.state.latestMilestoneIndex}
                                             frequencyTarget={this._networkConfig?.milestoneInterval}

--- a/client/src/app/routes/chrysalis/Landing.tsx
+++ b/client/src/app/routes/chrysalis/Landing.tsx
@@ -93,7 +93,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
      * @returns The node to render.
      */
     public render(): ReactNode {
-        const isLatestMilesontFeedInfoEnabled = this._networkConfig &&
+        const isLatestMilesoneFeedInfoEnabled = this._networkConfig &&
             this._networkConfig.network !== LEGACY_MAINNET &&
             this._networkConfig.network !== CUSTOM;
 
@@ -256,10 +256,9 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                             )}
                                         </div>
                                     </div>
-                                    {isLatestMilesontFeedInfoEnabled && (
+                                    {isLatestMilesoneFeedInfoEnabled && (
                                         <FeedInfo
                                             milestoneIndex={this.state.latestMilestoneIndex}
-                                            milestoneTimestamp={this.state.latestMilestoneTimestamp}
                                             frequencyTarget={this._networkConfig?.milestoneInterval}
                                         />
                                     )}

--- a/client/src/app/routes/stardust/Landing.tsx
+++ b/client/src/app/routes/stardust/Landing.tsx
@@ -103,8 +103,7 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
         const {
             networkConfig, marketCapCurrency, priceCurrency,
             valuesFilter, filteredItems, isFeedPaused,
-            isFilterExpanded, itemsPerSecond, confirmedItemsPerSecondPercent,
-            latestMilestoneIndex, latestMilestoneTimestamp
+            isFilterExpanded, itemsPerSecond, confirmedItemsPerSecondPercent, latestMilestoneIndex
         } = this.state;
 
         const { network } = this.props.match.params;
@@ -255,7 +254,6 @@ class Landing extends Feeds<RouteComponentProps<LandingRouteProps>, LandingState
                                     </div>
                                     <FeedInfo
                                         milestoneIndex={latestMilestoneIndex}
-                                        milestoneTimestamp={latestMilestoneTimestamp}
                                         frequencyTarget={networkConfig.milestoneInterval}
                                     />
 


### PR DESCRIPTION
# Description of change

- Interval counting time since last milestone is not tied to the milestone timestamp anymore

Interval just restarts from 0 every-time the milestone changes

Aims to fix https://github.com/iotaledger/explorer/issues/427

## Type of change

- Enhancement (a non-breaking change which adds functionality)
