### PR TITLE
Feat: Add amount column in associated outputs

### DIFF
--- a/client/src/app/components/stardust/AssociatedOutput.tsx
+++ b/client/src/app/components/stardust/AssociatedOutput.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable jsdoc/require-param */
 /* eslint-disable jsdoc/require-returns */
-import React from "react";
+import React, { useContext, useState } from "react";
 import { DateHelper } from "../../../helpers/dateHelper";
+import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import { AssociationType, IAssociatedOutput } from "../../../models/api/stardust/IAssociatedOutputsResponse";
+import NetworkContext from "../../context/NetworkContext";
 import Tooltip from "../Tooltip";
 import Output from "./Output";
 
@@ -39,6 +41,9 @@ const AssociatedOutput: React.FC<AssociatedOutputProps> = ({ network, associated
     const output = outputDetails.output;
     const outputMetadata = outputDetails.metadata;
     const dateCreated = DateHelper.formatShort(outputMetadata.milestoneTimestampBooked * 1000);
+    const { tokenInfo } = useContext(NetworkContext);
+    const [formatBalance, setFormatBalance] = useState(false);
+    const amount = output.amount;
 
     const associationLabel = ASSOCIATION_TYPE_TO_LABEL[associations[0]];
     const additionalAssociationsLabel = associations.length > 1 ? `+${associations.length - 1} more` : null;
@@ -73,6 +78,14 @@ const AssociatedOutput: React.FC<AssociatedOutputProps> = ({ network, associated
                 </div>
             </td>
             <td className="date-created">{dateCreated}</td>
+            <td className="amount">
+                <span
+                    onClick={() => setFormatBalance(!formatBalance)}
+                    className="pointer margin-r-5"
+                >
+                    {formatAmount(Number(amount), tokenInfo, formatBalance)}
+                </span>
+            </td>
         </tr>
     );
 
@@ -106,6 +119,17 @@ const AssociatedOutput: React.FC<AssociatedOutputProps> = ({ network, associated
             <div className="field date-created">
                 <div className="label">Date created</div>
                 <div className="value">{dateCreated}</div>
+            </div>
+            <div className="field amount">
+                <div className="label">Amount</div>
+                <div className="value">
+                    <span
+                        onClick={() => setFormatBalance(!formatBalance)}
+                        className="pointer margin-r-5"
+                    >
+                        {formatAmount(Number(amount), tokenInfo, formatBalance)}
+                    </span>
+                </div>
             </div>
         </div>
     );

--- a/client/src/app/components/stardust/AssociatedOutputsTable.scss
+++ b/client/src/app/components/stardust/AssociatedOutputsTable.scss
@@ -128,7 +128,7 @@
         }
 
         tr {
-            .found-in, .date-created {
+            .found-in, .date-created, .amount {
                 color: $gray-6;
             }
 
@@ -138,7 +138,7 @@
         }
 
         .card {
-            .found-in, .date-created {
+            .found-in, .date-created, .amount {
                 .value {
                     color: $gray-6;
                 }

--- a/client/src/app/components/stardust/AssociatedOutputsTable.tsx
+++ b/client/src/app/components/stardust/AssociatedOutputsTable.tsx
@@ -125,6 +125,7 @@ const AssociatedOutputsTable: React.FC<AssociatedOutputsTableProps> = ({ network
                             <th>Output type</th>
                             <th>Address found in</th>
                             <th>Date created</th>
+                            <th>Amount</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
# Description of change

- Added a column `Amount` in associated outputs table.
- Implemented a toggle on amount to see raw and smr value.

Aims to complete https://github.com/iotaledger/explorer/issues/449

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Address = `rms1qq3v8m2hjvflnau3zqm4qw4j9ufmy3qv26ggus28z9wts3n5up82kxhu7m5`
Search this address and you can see the change in associated outputs section.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
