### PR TITLE
Feat: Configurable fallback for API calls

### DIFF
--- a/api/src/models/db/INetwork.ts
+++ b/api/src/models/db/INetwork.ts
@@ -124,4 +124,11 @@ export interface INetwork {
      * Targeted interval in seconds between milestones.
      */
     milestoneInterval?: number;
+
+    /**
+     * Is API calls fallback disabled.
+     * If both permanode and node are configured, and this is true, API calls will only try calling permanode
+     * without falling back on node on failure.
+     */
+    disableApiFallback?: boolean;
 }

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -483,9 +483,10 @@ export class StardustTangleHelper {
         isIndexerCall: boolean = false
     ): Promise<R> | null {
         const {
-            provider, user, password,
-            permaNodeEndpoint, permaNodeEndpointUser, permaNodeEndpointPassword, disableApiFallback
+            provider, user, password, permaNodeEndpoint,
+            permaNodeEndpointUser, permaNodeEndpointPassword, disableApiFallback
         } = network;
+        const isFallbackEnabled = !disableApiFallback;
 
         if (permaNodeEndpoint) {
             const permanode = !isIndexerCall ?
@@ -507,7 +508,7 @@ export class StardustTangleHelper {
             } catch {}
         }
 
-        if (!permaNodeEndpoint || !disableApiFallback) {
+        if (!permaNodeEndpoint || isFallbackEnabled) {
             const node = !isIndexerCall ?
                 new SingleNodeClient(provider, { userName: user, password }) :
                 new IndexerPluginClient(

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -484,9 +484,8 @@ export class StardustTangleHelper {
     ): Promise<R> | null {
         const {
             provider, user, password,
-            permaNodeEndpoint, permaNodeEndpointUser, permaNodeEndpointPassword
+            permaNodeEndpoint, permaNodeEndpointUser, permaNodeEndpointPassword, disableApiFallback
         } = network;
-        const fallBackDisabled = network.disableApiFallback === true;
 
         if (permaNodeEndpoint) {
             const permanode = !isIndexerCall ?
@@ -508,7 +507,7 @@ export class StardustTangleHelper {
             } catch {}
         }
 
-        if (!permaNodeEndpoint || !fallBackDisabled) {
+        if (!permaNodeEndpoint || !disableApiFallback) {
             const node = !isIndexerCall ?
                 new SingleNodeClient(provider, { userName: user, password }) :
                 new IndexerPluginClient(

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -486,6 +486,8 @@ export class StardustTangleHelper {
             provider, user, password,
             permaNodeEndpoint, permaNodeEndpointUser, permaNodeEndpointPassword
         } = network;
+        const fallBackDisabled = network.disableApiFallback === true;
+
         if (permaNodeEndpoint) {
             const permanode = !isIndexerCall ?
                 new SingleNodeClient(
@@ -506,17 +508,19 @@ export class StardustTangleHelper {
             } catch {}
         }
 
-        const node = !isIndexerCall ?
-            new SingleNodeClient(provider, { userName: user, password }) :
-            new IndexerPluginClient(
-                new SingleNodeClient(provider, { userName: user, password })
+        if (!permaNodeEndpoint || !fallBackDisabled) {
+            const node = !isIndexerCall ?
+                new SingleNodeClient(provider, { userName: user, password }) :
+                new IndexerPluginClient(
+                    new SingleNodeClient(provider, { userName: user, password })
             );
 
-        try {
-            // try fetch from node
-            const result: Promise<R> = node[methodName](args);
-            return await result;
-        } catch {}
+            try {
+                // try fetch from node
+                const result: Promise<R> = node[methodName](args);
+                return await result;
+            } catch {}
+        }
 
         return null;
     }


### PR DESCRIPTION
# Description of change

Support configurable "fallback" in API calls
- Added an optional boolean `disableApiFallback' to networks configuration
- If set to true, **and** permanode and node are both configured, fallback will be disabled. Meaning that only permanode will be called, with no call to node on failure.
If permanode is **not** configured, setting the option to true has no effect, as node API will be used anyway.

Aims to complete https://github.com/iotaledger/explorer/issues/452

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
