### PR TITLE
Feat: Truncate output id in Output component

### DIFF
--- a/client/src/app/components/CopyButton.scss
+++ b/client/src/app/components/CopyButton.scss
@@ -17,6 +17,7 @@
     }
 
     &:hover {
+      text-decoration: none!important;
       span {
         color: $main-green-highlight!important;
       }

--- a/client/src/app/components/CopyButton.scss
+++ b/client/src/app/components/CopyButton.scss
@@ -4,62 +4,31 @@
 @import "../../scss/media-queries";
 
 .copy-button {
-  position: relative;
-
   .copy-button-btn {
     border: 0;
     outline: none;
+    padding: 0;
     background: none;
     cursor: pointer;
 
     span {
-      color: $gray-10;
-      font-size: 16px;
+      color: $gray-10!important;
+      font-size: 16px!important;
     }
 
     &:hover {
       span {
-        color: $main-green-highlight;
+        color: $main-green-highlight!important;
       }
     }
   }
 
   .copy-button--message {
-    @include font-size(10px, 12px);
+    line-height: 0!important;
 
-    position: absolute;
-    top: 10px;
-    right: 0;
-    min-width: 50px;
-    transform: translateX(100%);
-    animation: fade 2s linear;
-    opacity: 1;
-    color: $main-green;
-    font-family: $metropolis;
-    font-weight: bold;
-    text-transform: uppercase;
-    animation-fill-mode: forwards;
-
-    &.bottom {
-        top: 25px;
-        transform: translateX(25%);
-    }
-
-    &.top {
-        top: -20px;
-        transform: translateX(25%);
-    }
-  }
-
-
-  @keyframes fade {
-    0%,
-    100% {
-      opacity: 0;
-    }
-
-    50% {
-      opacity: 1;
+    span {
+        color: $main-green!important;
+        font-size: 16px!important;
     }
   }
 }

--- a/client/src/app/components/CopyButton.tsx
+++ b/client/src/app/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React, { Component, ReactNode } from "react";
+import { ClipboardHelper } from "../../helpers/clipboardHelper";
 import "./CopyButton.scss";
 import { CopyButtonProps } from "./CopyButtonProps";
 import { CopyButtonState } from "./CopyButtonState";
@@ -16,8 +17,7 @@ class CopyButton extends Component<CopyButtonProps, CopyButtonState> {
         super(props);
 
         this.state = {
-            active: false,
-            message: props.buttonType === "copy" ? "Copied" : ""
+            active: false
         };
     }
 
@@ -28,24 +28,20 @@ class CopyButton extends Component<CopyButtonProps, CopyButtonState> {
     public render(): ReactNode {
         return (
             <div className="copy-button">
-                <button
-                    type="button"
-                    className={classNames(
-                        "copy-button-btn",
-                        { "copy-button-btn--active": this.state.active }
-                    )}
-                    onClick={e => this.activate(e)}
-                >
-                    {this.props.buttonType === "copy" && (
+                {!this.state.active ? (
+                    <button
+                        type="button"
+                        className={classNames("copy-button-btn", { "copy-button-btn--active": this.state.active })}
+                        onClick={e => this.activate(e)}
+                    >
                         <span className="material-icons">
                             content_copy
                         </span>
-                    )}
-                </button>
-                {this.state.active && this.state.message && (
-                    <span className={classNames("copy-button--message", this.props.labelPosition)}>
-                        {this.state.message}
-                    </span>
+                    </button>
+                ) : (
+                    <div className="copy-button--message">
+                        <span className="material-icons">done</span>
+                    </div>
                 )}
             </div>
         );
@@ -56,7 +52,10 @@ class CopyButton extends Component<CopyButtonProps, CopyButtonState> {
      * @param event The mouse click event
      */
     private activate(event: React.MouseEvent): void {
-        this.props.onClick(event);
+        ClipboardHelper.copy(this.props.copy);
+        if (event) {
+            event.stopPropagation();
+        }
 
         this.setState({ active: true });
         setTimeout(

--- a/client/src/app/components/CopyButtonProps.tsx
+++ b/client/src/app/components/CopyButtonProps.tsx
@@ -1,16 +1,6 @@
 export interface CopyButtonProps {
     /**
-     * The type of button to show.
+     * The string to copy to clipboard.
      */
-    buttonType: "copy";
-
-    /**
-     * Position to show copied label.
-     */
-    labelPosition?: "top" | "right" | "bottom";
-
-    /**
-     * The button click.
-     */
-    onClick(event?: React.MouseEvent): void;
+    copy: string | undefined;
 }

--- a/client/src/app/components/CopyButtonState.tsx
+++ b/client/src/app/components/CopyButtonState.tsx
@@ -3,9 +3,4 @@ export interface CopyButtonState {
      * Is the message active.
      */
     active: boolean;
-
-    /**
-     * The message to show.
-     */
-    message: string;
 }

--- a/client/src/app/components/chrysalis/Bech32Address.tsx
+++ b/client/src/app/components/chrysalis/Bech32Address.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 import React, { Component, ReactNode } from "react";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { Bech32AddressProps } from "../Bech32AddressProps";
 import CopyButton from "../CopyButton";
 
@@ -39,13 +38,7 @@ class Bech32Address extends Component<Bech32AddressProps> {
                             {!this.props.history && (
                                 <span className="margin-r-t">{this.props.addressDetails.bech32}</span>
                             )}
-                            {this.props.showCopyButton && (
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(this.props.addressDetails?.bech32)}
-                                    buttonType="copy"
-                                    labelPosition={this.props.labelPosition ?? "right"}
-                                />
-                            )}
+                            {this.props.showCopyButton && <CopyButton copy={this.props.addressDetails?.bech32} />}
                         </div>
                     </div>
                 )}
@@ -69,11 +62,7 @@ class Bech32Address extends Component<Bech32AddressProps> {
                             {!this.props.history && (
                                 <span className="margin-r-t">{this.props.addressDetails?.hex}</span>
                             )}
-                            <CopyButton
-                                onClick={() => ClipboardHelper.copy(this.props.addressDetails?.hex)}
-                                buttonType="copy"
-                                labelPosition={this.props.labelPosition ?? "right"}
-                            />
+                            <CopyButton copy={this.props.addressDetails?.hex} />
                         </div>
                     </div>
                 )}

--- a/client/src/app/components/chrysalis/Output.tsx
+++ b/client/src/app/components/chrysalis/Output.tsx
@@ -4,7 +4,6 @@ import { WriteStream } from "@iota/util.js";
 import React, { Component, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { NameHelper } from "../../../helpers/chrysalis/nameHelper";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import CopyButton from "../CopyButton";
 import { OutputState } from "../OutputState";
 import { OutputProps } from "./OutputProps";
@@ -61,12 +60,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 >
                                     {this.props.output.messageId}
                                 </Link>
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(
-                                        this.props.output.messageId
-                                    )}
-                                    buttonType="copy"
-                                />
+                                <CopyButton copy={this.props.output.messageId} />
                             </React.Fragment>
                         )}
                     </div>
@@ -92,12 +86,7 @@ class Output extends Component<OutputProps, OutputState> {
                                                 {this.props.output.transactionId}
                                             </Link>
                                         </span>
-                                        <CopyButton
-                                            onClick={() => ClipboardHelper.copy(
-                                                this.props.output.transactionId
-                                            )}
-                                            buttonType="copy"
-                                        />
+                                        <CopyButton copy={this.props.output.transactionId} />
                                     </React.Fragment>
                                 )}
                             </div>

--- a/client/src/app/components/chrysalis/TransactionPayload.tsx
+++ b/client/src/app/components/chrysalis/TransactionPayload.tsx
@@ -3,7 +3,6 @@ import { UnitsHelper } from "@iota/iota.js";
 import classNames from "classnames";
 import React, { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import AsyncComponent from "../AsyncComponent";
 import CopyButton from "../CopyButton";
 import FiatValue from "../FiatValue";
@@ -174,11 +173,7 @@ class TransactionPayload extends AsyncComponent<TransactionPayloadProps, Transac
                                             >
                                                 {this.state.isFormattedBalance ? output.amount : UnitsHelper.formatBest(output.amount)}
                                             </span>
-                                            <CopyButton
-                                                onClick={() => ClipboardHelper.copy(String(output.amount))}
-                                                buttonType="copy"
-                                                labelPosition="bottom"
-                                            />
+                                            <CopyButton copy={String(output.amount)} />
                                         </div>
                                     </div>
 

--- a/client/src/app/components/stardust/Address.tsx
+++ b/client/src/app/components/stardust/Address.tsx
@@ -26,6 +26,7 @@ class Address extends Component<AddressProps> {
             this.props.address
         ).bech32;
 
+        const bech32Short = `${bech32.slice(0, 12)}....${bech32.slice(-12)}`;
         return (
             <div className="address-type">
                 <div className="card--label">
@@ -36,7 +37,7 @@ class Address extends Component<AddressProps> {
                         to={`/${this.context.name}/addr/${bech32}`}
                         className="margin-r-t"
                     >
-                        {bech32}
+                        {bech32Short}
                     </Link>
                     <CopyButton
                         onClick={() => ClipboardHelper.copy(bech32)}

--- a/client/src/app/components/stardust/Address.tsx
+++ b/client/src/app/components/stardust/Address.tsx
@@ -1,6 +1,5 @@
 import React, { Component, ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { Bech32AddressHelper } from "../../../helpers/stardust/bech32AddressHelper";
 import { NameHelper } from "../../../helpers/stardust/nameHelper";
 import NetworkContext from "../../context/NetworkContext";
@@ -39,11 +38,7 @@ class Address extends Component<AddressProps> {
                     >
                         {bech32Short}
                     </Link>
-                    <CopyButton
-                        onClick={() => ClipboardHelper.copy(bech32)}
-                        buttonType="copy"
-                        labelPosition="bottom"
-                    />
+                    <CopyButton copy={bech32} />
                 </div>
             </div>
         );

--- a/client/src/app/components/stardust/AddressBalance.tsx
+++ b/client/src/app/components/stardust/AddressBalance.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from "react";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { isMarketedNetwork } from "../../../helpers/networkHelper";
 import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import CopyButton from "../../components/CopyButton";
@@ -56,11 +55,7 @@ const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalan
                             >
                                 {formatAmount(amount, tokenInfo, isFormatFull)}
                             </span>
-                            <CopyButton
-                                onClick={() => ClipboardHelper.copy(String(amount))}
-                                buttonType="copy"
-                                labelPosition="bottom"
-                            />
+                            <CopyButton copy={String(amount)} />
                         </div>
                         {isMarketed && (
                             <React.Fragment>

--- a/client/src/app/components/stardust/AssociatedOutputsTable.scss
+++ b/client/src/app/components/stardust/AssociatedOutputsTable.scss
@@ -39,7 +39,7 @@
           td {
               border: none;
               color: var(--body-color);
-              padding: 8px 4px;
+              padding: 12px 4px;
               &:first-child {
                   padding-left: 2px;
               }
@@ -94,12 +94,9 @@
                 .card-header--wrapper {
                     margin: 0px;
                 }
-
-                .output-header {
-                    flex-direction: column;
-                }
             }
         }
+
         .output--label {
             display: flex;
 
@@ -128,17 +125,23 @@
         }
 
         tr {
-            .found-in, .date-created, .amount {
+            .found-in, .date-created {
                 color: $gray-6;
             }
 
             .date-created {
                 font-family: $ibm-plex-mono;
             }
+
+            .amount {
+                color: $mint-green-7;
+                @include font-size(16px, 21px);
+                font-weight: 700;
+            }
         }
 
         .card {
-            .found-in, .date-created, .amount {
+            .found-in, .date-created {
                 .value {
                     color: $gray-6;
                 }
@@ -146,6 +149,12 @@
 
             .date-created .value {
                 font-family: $ibm-plex-mono;
+            }
+
+            .amount .value {
+                color: $mint-green-7;
+                @include font-size(16px, 21px);
+                font-weight: 700;
             }
         }
 

--- a/client/src/app/components/stardust/Bech32Address.tsx
+++ b/client/src/app/components/stardust/Bech32Address.tsx
@@ -1,5 +1,4 @@
 import React, { Component, ReactNode } from "react";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { Bech32AddressProps } from "../Bech32AddressProps";
 import CopyButton from "../CopyButton";
 
@@ -39,13 +38,7 @@ class Bech32Address extends Component<Bech32AddressProps> {
                             {!this.props.history && (
                                 <span className="margin-r-t">{this.props.addressDetails.bech32}</span>
                             )}
-                            {this.props.showCopyButton && (
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(this.props.addressDetails?.bech32)}
-                                    buttonType="copy"
-                                    labelPosition={this.props.labelPosition ?? "right"}
-                                />
-                            )}
+                            {this.props.showCopyButton && <CopyButton copy={this.props.addressDetails?.bech32} />}
                         </div>
                     </div>
                 )}
@@ -69,11 +62,7 @@ class Bech32Address extends Component<Bech32AddressProps> {
                             {!this.props.history && (
                                 <span className="margin-r-t">{this.props.addressDetails?.hex}</span>
                             )}
-                            <CopyButton
-                                onClick={() => ClipboardHelper.copy(this.props.addressDetails?.hex)}
-                                buttonType="copy"
-                                labelPosition={this.props.labelPosition ?? "right"}
-                            />
+                            <CopyButton copy={this.props.addressDetails?.hex} />
                         </div>
                     </div>
                 )}

--- a/client/src/app/components/stardust/Output.scss
+++ b/client/src/app/components/stardust/Output.scss
@@ -2,7 +2,7 @@
 @import "../../../scss/variables";
 
 .card--content__output {
-    padding: 0 30px 20px;
+    padding: 0 30px;
 
     .card--value.card-header--wrapper {
         width: 100%;
@@ -18,6 +18,8 @@
             }
 
             .output-id--link {
+                display: flex;
+
                 a {
                     margin-right: 0px;
                 }
@@ -27,10 +29,10 @@
                     color: $gray-6;
                     margin-left: 2px;
                 }
-            }
 
-            @include desktop-down {
-                flex-direction: column;
+                .copy-button {
+                    margin-left: 4px;
+                }
             }
         }
 

--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -51,13 +51,15 @@ class Output extends Component<OutputProps, OutputState> {
      * @returns The node to render.
      */
     public render(): ReactNode {
-        const { outputId, output, amount, showCopyAmount, network, isPreExpanded } = this.props;
+        const { outputId, output, amount, showCopyAmount, network, isPreExpanded, displayFullOutputId } = this.props;
         const { isExpanded, isFormattedBalance } = this.state;
 
         const aliasOrNftBech32 = this.buildAddressForAliasOrNft();
         const foundryId = this.buildFoundyId();
 
-        const outputIdTransactionPart = outputId.slice(0, -4);
+        const outputIdTransactionPart = displayFullOutputId ?
+            `${outputId.slice(0, -4)}` :
+            `${outputId.slice(0, 8)}....${outputId.slice(-8, -4)}`;
         const outputIdIndexPart = outputId.slice(-4);
 
         const outputHeader = (
@@ -82,6 +84,16 @@ class Output extends Component<OutputProps, OutputState> {
                             <span className="highlight">{outputIdIndexPart}</span>
                         </Link>
                         )
+                        <CopyButton
+                            onClick={e => {
+                                ClipboardHelper.copy(String(outputId));
+                                if (e) {
+                                    e.stopPropagation();
+                                }
+                            }}
+                            buttonType="copy"
+                            labelPosition="bottom"
+                        />
                     </div>
                 </div>
                 {showCopyAmount && (

--- a/client/src/app/components/stardust/Output.tsx
+++ b/client/src/app/components/stardust/Output.tsx
@@ -9,7 +9,6 @@ import bigInt from "big-integer";
 import classNames from "classnames";
 import React, { Component, ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { Bech32AddressHelper } from "../../../helpers/stardust/bech32AddressHelper";
 import { NameHelper } from "../../../helpers/stardust/nameHelper";
 import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
@@ -84,16 +83,7 @@ class Output extends Component<OutputProps, OutputState> {
                             <span className="highlight">{outputIdIndexPart}</span>
                         </Link>
                         )
-                        <CopyButton
-                            onClick={e => {
-                                ClipboardHelper.copy(String(outputId));
-                                if (e) {
-                                    e.stopPropagation();
-                                }
-                            }}
-                            buttonType="copy"
-                            labelPosition="bottom"
-                        />
+                        <CopyButton copy={String(outputId)} />
                     </div>
                 </div>
                 {showCopyAmount && (
@@ -109,17 +99,7 @@ class Output extends Component<OutputProps, OutputState> {
                         </span>
                     </div>
                 )}
-                {showCopyAmount &&
-                    <CopyButton
-                        onClick={e => {
-                            ClipboardHelper.copy(String(amount));
-                            if (e) {
-                                e.stopPropagation();
-                            }
-                        }}
-                        buttonType="copy"
-                        labelPosition="bottom"
-                    />}
+                {showCopyAmount && <CopyButton copy={String(amount)} />}
             </div>
         );
 
@@ -137,11 +117,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 <Link to={`/${network}/search/${aliasOrNftBech32}`} className="margin-r-t">
                                     {aliasOrNftBech32}
                                 </Link>
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(aliasOrNftBech32)}
-                                    buttonType="copy"
-                                    labelPosition="bottom"
-                                />
+                                <CopyButton copy={aliasOrNftBech32} />
                             </div>
                             <div className="card--label">
                                 State index:
@@ -180,10 +156,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 <Link to={`/${network}/search/${aliasOrNftBech32}`} className="margin-r-t">
                                     {aliasOrNftBech32}
                                 </Link>
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(aliasOrNftBech32)}
-                                    buttonType="copy"
-                                />
+                                <CopyButton copy={aliasOrNftBech32} />
                             </div>
                         </React.Fragment>
                         )}
@@ -200,10 +173,7 @@ class Output extends Component<OutputProps, OutputState> {
                                 >
                                     {foundryId}
                                 </Link>
-                                <CopyButton
-                                    onClick={() => ClipboardHelper.copy(foundryId)}
-                                    buttonType="copy"
-                                />
+                                <CopyButton copy={foundryId} />
                             </div>
                             <div className="card--label">
                                 Serial number:

--- a/client/src/app/components/stardust/OutputProps.tsx
+++ b/client/src/app/components/stardust/OutputProps.tsx
@@ -22,9 +22,14 @@ export interface OutputProps {
     showCopyAmount: boolean;
 
     /**
-     * Should the output be pre-expanded
+     * Should the output be pre-expanded.
      */
     isPreExpanded?: boolean;
+
+    /**
+     * Should the outputId be displayed in full (default truncated).
+     */
+    displayFullOutputId?: boolean;
 
     /**
      * The network to lookup.

--- a/client/src/app/components/stardust/TransactionPayload.scss
+++ b/client/src/app/components/stardust/TransactionPayload.scss
@@ -84,6 +84,6 @@
   }
 
   .transaction-from.card--content .card--content__output {
-      padding: 0 0 20px;
+      padding: 0 0;
   }
 }

--- a/client/src/app/routes/IdentityResolver.tsx
+++ b/client/src/app/routes/IdentityResolver.tsx
@@ -4,7 +4,6 @@ import React, { Fragment, ReactNode } from "react";
 import { HiDownload } from "react-icons/hi";
 import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../factories/serviceFactory";
-import { ClipboardHelper } from "../../helpers/clipboardHelper";
 import { DownloadHelper } from "../../helpers/downloadHelper";
 import { CHRYSALIS } from "../../models/config/protocolVersion";
 import { TangleStatus } from "../../models/tangleStatus";
@@ -241,10 +240,7 @@ class IdentityResolver extends AsyncComponent<
                                                     <div className="label">DID</div>
                                                     <div className="row middle value code highlight margin-b-s">
                                                         <div className="margin-r-t">{this.state.did}</div>
-                                                        <CopyButton
-                                                            onClick={() => ClipboardHelper.copy(this.state.did)}
-                                                            buttonType="copy"
-                                                        />
+                                                        <CopyButton copy={this.state.did} />
                                                     </div>
                                                     {this.state.resolvedIdentity &&
                                                         !this.state.error &&
@@ -257,12 +253,7 @@ class IdentityResolver extends AsyncComponent<
                                                                         {this.state.resolvedIdentity?.messageId}
                                                                     </div>
                                                                     <CopyButton
-                                                                        onClick={() =>
-                                                                            ClipboardHelper.copy(
-                                                                                this.state.resolvedIdentity
-                                                                                    ?.messageId
-                                                                            )}
-                                                                        buttonType="copy"
+                                                                        copy={this.state.resolvedIdentity?.messageId}
                                                                     />
                                                                 </div>
                                                             </Fragment>

--- a/client/src/app/routes/StreamsV0.tsx
+++ b/client/src/app/routes/StreamsV0.tsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import React, { ReactNode } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../factories/serviceFactory";
-import { ClipboardHelper } from "../../helpers/clipboardHelper";
 import { TrytesHelper } from "../../helpers/trytesHelper";
 import { CHRYSALIS } from "../../models/config/protocolVersion";
 import { ChrysalisTangleCacheService } from "../../services/chrysalis/chrysalisTangleCacheService";
@@ -252,11 +251,11 @@ class StreamsV0 extends AsyncComponent<RouteComponentProps<StreamsV0RouteProps>,
                                                         )}
                                                     </span>
                                                     <CopyButton
-                                                        onClick={() => ClipboardHelper.copy(
-                                                            item.showRawMessageTrytes
-                                                                ? item.rawMessageTrytes
-                                                                : item.message)}
-                                                        buttonType="copy"
+                                                        copy={
+                                                            item.showRawMessageTrytes ?
+                                                            item.rawMessageTrytes :
+                                                            item.message
+                                                        }
                                                     />
                                                 </div>
                                                 <div

--- a/client/src/app/routes/chrysalis/Addr.tsx
+++ b/client/src/app/routes/chrysalis/Addr.tsx
@@ -7,7 +7,6 @@ import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
 import { Bech32AddressHelper } from "../../../helpers/chrysalis/bech32AddressHelper";
 import { TransactionsHelper } from "../../../helpers/chrysalis/transactionsHelper";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import {
     HistoricInput, HistoricOutput,
     ITransaction, ITransactionsDetailsResponse
@@ -206,10 +205,7 @@ class Addr extends AsyncComponent<RouteComponentProps<AddressRouteProps>, AddrSt
                                                                     <span>(</span>
                                                                     <FiatValue value={this.state.balance} />
                                                                     <span>)</span>
-                                                                    <CopyButton
-                                                                        onClick={() => ClipboardHelper.copy(String(this.state.balance))}
-                                                                        buttonType="copy"
-                                                                    />
+                                                                    <CopyButton copy={String(this.state.balance)} />
                                                                 </div>
                                                             ) : 0}
                                                         </div>

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -3,7 +3,6 @@ import React, { ReactNode } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
 import { TransactionsHelper } from "../../../helpers/chrysalis/transactionsHelper";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { CHRYSALIS } from "../../../models/config/protocolVersion";
 import { TangleStatus } from "../../../models/tangleStatus";
 import { ChrysalisTangleCacheService } from "../../../services/chrysalis/chrysalisTangleCacheService";
@@ -154,12 +153,7 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
                                     <span className="margin-r-t">
                                         {this.state.actualMessageId}
                                     </span>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(
-                                            this.state.actualMessageId
-                                        )}
-                                        buttonType="copy"
-                                    />
+                                    <CopyButton copy={this.state.actualMessageId} />
                                 </div>
                             </div>
 
@@ -170,12 +164,7 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
                                     </div>
                                     <div className="value value__secondary row middle">
                                         <span className="margin-r-t">{this.state.paramMessageId}</span>
-                                        <CopyButton
-                                            onClick={() => ClipboardHelper.copy(
-                                                this.state.paramMessageId
-                                            )}
-                                            buttonType="copy"
-                                        />
+                                        <CopyButton copy={this.state.paramMessageId} />
                                     </div>
                                 </div>
                             )}

--- a/client/src/app/routes/og/Address.tsx
+++ b/client/src/app/routes/og/Address.tsx
@@ -4,7 +4,6 @@ import classNames from "classnames";
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { DateHelper } from "../../../helpers/dateHelper";
 import { TrytesHelper } from "../../../helpers/trytesHelper";
 import { ICachedTransaction } from "../../../models/api/ICachedTransaction";
@@ -191,12 +190,7 @@ class Address extends AsyncComponent<RouteComponentProps<AddressRouteProps>, Add
                                                     {this.state.checksum}
                                                 </span>
                                             </span>
-                                            <CopyButton
-                                                onClick={() => ClipboardHelper.copy(
-                                                    `${this.state.address}${this.state.checksum}`
-                                                )}
-                                                buttonType="copy"
-                                            />
+                                            <CopyButton copy={`${this.state.address}${this.state.checksum}`} />
                                         </div>
                                         {this.state.balance !== undefined && this.state.balance !== 0 && (
                                             <div className="row fill margin-t-s margin-b-s value-buttons">

--- a/client/src/app/routes/og/Bundle.tsx
+++ b/client/src/app/routes/og/Bundle.tsx
@@ -2,7 +2,6 @@ import { UnitsHelper } from "@iota/iota.js";
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { DateHelper } from "../../../helpers/dateHelper";
 import { TrytesHelper } from "../../../helpers/trytesHelper";
 import { ICachedTransaction } from "../../../models/api/ICachedTransaction";
@@ -217,11 +216,7 @@ class Bundle extends Currency<RouteComponentProps<BundleRouteProps>, BundleState
                                         </div>
                                         <div className="card--value row middle">
                                             <span className="margin-r-t">{this.state.bundle}</span>
-                                            <CopyButton
-                                                onClick={() => ClipboardHelper.copy(
-                                                    this.state.bundle)}
-                                                buttonType="copy"
-                                            />
+                                            <CopyButton copy={this.state.bundle} />
                                         </div>
                                     </div>
                                 </div>

--- a/client/src/app/routes/og/Tag.tsx
+++ b/client/src/app/routes/og/Tag.tsx
@@ -3,7 +3,6 @@ import classNames from "classnames";
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { DateHelper } from "../../../helpers/dateHelper";
 import { TrytesHelper } from "../../../helpers/trytesHelper";
 import { ICachedTransaction } from "../../../models/api/ICachedTransaction";
@@ -186,11 +185,7 @@ class Tag extends AsyncComponent<RouteComponentProps<TagRouteProps>, TagState> {
                                                     {this.state.tagFill}
                                                 </span>
                                             </span>
-                                            <CopyButton
-                                                onClick={() => ClipboardHelper.copy(
-                                                    this.state.tag)}
-                                                buttonType="copy"
-                                            />
+                                            <CopyButton copy={this.state.tag} />
                                         </div>
                                         <div className="card--label">
                                             Transaction Filter

--- a/client/src/app/routes/og/Transaction.tsx
+++ b/client/src/app/routes/og/Transaction.tsx
@@ -7,7 +7,6 @@ import classNames from "classnames";
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { DateHelper } from "../../../helpers/dateHelper";
 import { TrytesHelper } from "../../../helpers/trytesHelper";
 import { ICachedTransaction } from "../../../models/api/ICachedTransaction";
@@ -165,10 +164,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                         </div>
                                         <div className="card--value row middle">
                                             <span className="margin-r-t">{this.state.hash}</span>
-                                            <CopyButton
-                                                onClick={() => ClipboardHelper.copy(this.state.hash)}
-                                                buttonType="copy"
-                                            />
+                                            <CopyButton copy={this.state.hash} />
                                         </div>
                                         {this.state.details && (
                                             <React.Fragment>
@@ -211,12 +207,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                             {this.state.checksum}
                                                         </span>
                                                     </Link>
-                                                    <CopyButton
-                                                        onClick={() => ClipboardHelper.copy(
-                                                            `${this.state.address}${this.state.checksum}`
-                                                        )}
-                                                        buttonType="copy"
-                                                    />
+                                                    <CopyButton copy={`${this.state.address}${this.state.checksum}`} />
                                                 </div>
                                                 {this.state.details.confirmationState === "pending" &&
                                                     this.state.isBundleValid === "valid" && (
@@ -266,10 +257,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                                             {this.state.actionResultHash}
                                                                         </Link>
                                                                         <CopyButton
-                                                                            onClick={() => ClipboardHelper.copy(
-                                                                                this.state.actionResultHash
-                                                                            )}
-                                                                            buttonType="copy"
+                                                                            copy={this.state.actionResultHash}
                                                                         />
                                                                     </div>
                                                                 </React.Fragment>
@@ -332,11 +320,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                     >
                                                         {this.state.details?.tx.bundle}
                                                     </Link>
-                                                    <CopyButton
-                                                        onClick={() => ClipboardHelper.copy(
-                                                            this.state.details?.tx.bundle)}
-                                                        buttonType="copy"
-                                                    />
+                                                    <CopyButton copy={this.state.details?.tx.bundle} />
                                                 </div>
 
                                                 <div className="card--label">
@@ -399,11 +383,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                             >
                                                                 {this.state.details.tx.tag}
                                                             </Link>
-                                                            <CopyButton
-                                                                onClick={() => ClipboardHelper.copy(
-                                                                    this.state.details?.tx.tag)}
-                                                                buttonType="copy"
-                                                            />
+                                                            <CopyButton copy={this.state.details?.tx.tag} />
                                                         </div>
                                                     </div>
                                                     <div className="col fill">
@@ -420,11 +400,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                             >
                                                                 {this.state.details.tx.obsoleteTag}
                                                             </Link>
-                                                            <CopyButton
-                                                                onClick={() => ClipboardHelper.copy(
-                                                                    this.state.details?.tx.obsoleteTag)}
-                                                                buttonType="copy"
-                                                            />
+                                                            <CopyButton copy={this.state.details?.tx.obsoleteTag} />
                                                         </div>
                                                     </div>
                                                 </div>
@@ -467,12 +443,9 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                                     `Message ${this.state.messageType}`
                                                                 )}
                                                             </span>
-                                                            <CopyButton
-                                                                onClick={() => ClipboardHelper.copy(
-                                                                    this.state.showRawMessageTrytes
-                                                                        ? this.state.rawMessageTrytes
-                                                                        : this.state.message)}
-                                                                buttonType="copy"
+                                                            <CopyButton copy={this.state.showRawMessageTrytes ?
+                                                                this.state.rawMessageTrytes :
+                                                                this.state.message}
                                                             />
                                                         </div>
                                                         <div
@@ -601,10 +574,7 @@ class Transaction extends AsyncComponent<RouteComponentProps<TransactionRoutePro
                                                                 Trytes
                                                             </span>
                                                             {this.state.details && (
-                                                                <CopyButton
-                                                                    onClick={() => ClipboardHelper.copy(this.state.raw)}
-                                                                    buttonType="copy"
-                                                                />
+                                                                <CopyButton copy={this.state.raw} />
                                                             )}
                                                         </div>
                                                         <div

--- a/client/src/app/routes/stardust/Block.tsx
+++ b/client/src/app/routes/stardust/Block.tsx
@@ -5,7 +5,6 @@ import {
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { isMarketedNetwork } from "../../../helpers/networkHelper";
 import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import { STARDUST } from "../../../models/config/protocolVersion";
@@ -152,12 +151,7 @@ class Block extends AsyncComponent<RouteComponentProps<BlockProps>, BlockState> 
                                     <span className="margin-r-t">
                                         {blockId}
                                     </span>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(
-                                            blockId
-                                        )}
-                                        buttonType="copy"
-                                    />
+                                    <CopyButton copy={blockId} />
                                 </div>
                             </div>
 
@@ -173,12 +167,7 @@ class Block extends AsyncComponent<RouteComponentProps<BlockProps>, BlockState> 
                                         >
                                             {this.state.transactionId}
                                         </Link>
-                                        <CopyButton
-                                            onClick={() => ClipboardHelper.copy(
-                                                this.state.transactionId
-                                            )}
-                                            buttonType="copy"
-                                        />
+                                        <CopyButton copy={this.state.transactionId} />
                                     </div>
                                 </div>
                             )}

--- a/client/src/app/routes/stardust/Foundry.tsx
+++ b/client/src/app/routes/stardust/Foundry.tsx
@@ -4,7 +4,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { RouteComponentProps } from "react-router";
 import { Link } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { isMarketedNetwork } from "../../../helpers/networkHelper";
 import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import { STARDUST } from "../../../models/config/protocolVersion";
@@ -103,10 +102,7 @@ const Foundry: React.FC<RouteComponentProps<FoundryProps>> = (
                                 <Link to={`/${network}/search/${controllerAlias}`} className="margin-r-t">
                                     {controllerAlias}
                                 </Link>
-                                <CopyButton
-                                    buttonType="copy"
-                                    onClick={() => ClipboardHelper.copy(controllerAlias)}
-                                />
+                                <CopyButton copy={controllerAlias} />
                             </div>
                         </div>
 

--- a/client/src/app/routes/stardust/NftRegistryDetails.tsx
+++ b/client/src/app/routes/stardust/NftRegistryDetails.tsx
@@ -4,7 +4,6 @@ import { RouteComponentProps } from "react-router-dom";
 import { ReactComponent as DropdownIcon } from "../../../assets/dropdown-arrow.svg";
 import mainHeaderMessage from "../../../assets/modals/block/main-header.json";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { INftActivityHistory } from "../../../models/api/stardust/nft/INftRegistryDetailsResponse";
 import { STARDUST } from "../../../models/config/protocolVersion";
 import { StardustTangleCacheService } from "../../../services/stardust/stardustTangleCacheService";
@@ -132,12 +131,7 @@ class NftRegistryDetails extends AsyncComponent<RouteComponentProps<NftRegistryD
                                                                 <span className="label value">
                                                                     {nftDetails?.generalData?.tokenId}
                                                                 </span>
-                                                                <CopyButton
-                                                                    onClick={() => ClipboardHelper.copy(
-                                                                        nftDetails?.generalData?.tokenId
-                                                                    )}
-                                                                    buttonType="copy"
-                                                                />
+                                                                <CopyButton copy={nftDetails?.generalData?.tokenId} />
                                                             </div>
                                                         </li>
                                                         <li className="list">
@@ -147,10 +141,7 @@ class NftRegistryDetails extends AsyncComponent<RouteComponentProps<NftRegistryD
                                                                     {nftDetails?.generalData?.contractAddress}
                                                                 </span>
                                                                 <CopyButton
-                                                                    onClick={() => ClipboardHelper.copy(
-                                                                        nftDetails?.generalData?.contractAddress
-                                                                    )}
-                                                                    buttonType="copy"
+                                                                    copy={nftDetails?.generalData?.contractAddress}
                                                                 />
                                                             </div>
                                                         </li>
@@ -161,10 +152,7 @@ class NftRegistryDetails extends AsyncComponent<RouteComponentProps<NftRegistryD
                                                                     {nftDetails?.generalData?.creatorAddress}
                                                                 </span>
                                                                 <CopyButton
-                                                                    onClick={() => ClipboardHelper.copy(
-                                                                        nftDetails?.generalData?.creatorAddress
-                                                                    )}
-                                                                    buttonType="copy"
+                                                                    copy={nftDetails?.generalData?.creatorAddress}
                                                                 />
                                                             </div>
                                                         </li>
@@ -175,10 +163,7 @@ class NftRegistryDetails extends AsyncComponent<RouteComponentProps<NftRegistryD
                                                                     {nftDetails?.generalData?.senderAddress}
                                                                 </span>
                                                                 <CopyButton
-                                                                    onClick={() => ClipboardHelper.copy(
-                                                                        nftDetails?.generalData?.senderAddress
-                                                                    )}
-                                                                    buttonType="copy"
+                                                                    copy={nftDetails?.generalData?.senderAddress}
                                                                 />
                                                             </div>
                                                         </li>

--- a/client/src/app/routes/stardust/OutputPage.tsx
+++ b/client/src/app/routes/stardust/OutputPage.tsx
@@ -2,7 +2,6 @@ import { IOutputResponse } from "@iota/iota.js-stardust";
 import React, { useEffect, useState } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { DateHelper } from "../../../helpers/dateHelper";
 import { STARDUST } from "../../../models/config/protocolVersion";
 import { StardustTangleCacheService } from "../../../services/stardust/stardustTangleCacheService";
@@ -71,11 +70,7 @@ const OutputPage: React.FC<RouteComponentProps<OutputPageProps>> = (
                                     >
                                         {blockId}
                                     </Link>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(blockId)}
-                                        buttonType="copy"
-                                        labelPosition="bottom"
-                                    />
+                                    <CopyButton copy={blockId} />
                                 </div>
                             </div>
                         )}
@@ -92,11 +87,7 @@ const OutputPage: React.FC<RouteComponentProps<OutputPageProps>> = (
                                     >
                                         {transactionId}
                                     </Link>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(transactionId)}
-                                        buttonType="copy"
-                                        labelPosition="bottom"
-                                    />
+                                    <CopyButton copy={transactionId} />
                                 </div>
                             </div>
                         )}
@@ -165,11 +156,7 @@ const OutputPage: React.FC<RouteComponentProps<OutputPageProps>> = (
                                     >
                                         {transactionIdSpent}
                                     </Link>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(transactionIdSpent)}
-                                        buttonType="copy"
-                                        labelPosition="bottom"
-                                    />
+                                    <CopyButton copy={transactionIdSpent} />
                                 </div>
                             </div>
                         )}

--- a/client/src/app/routes/stardust/TransactionPage.tsx
+++ b/client/src/app/routes/stardust/TransactionPage.tsx
@@ -3,7 +3,6 @@ import { TRANSACTION_PAYLOAD_TYPE, TransactionHelper } from "@iota/iota.js-stard
 import React, { ReactNode } from "react";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
-import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { STARDUST } from "../../../models/config/protocolVersion";
 import { calculateConflictReason, calculateStatus } from "../../../models/tangleStatus";
 import { StardustTangleCacheService } from "../../../services/stardust/stardustTangleCacheService";
@@ -151,12 +150,7 @@ class TransactionPage extends AsyncComponent<RouteComponentProps<TransactionPage
                                     <span className="margin-r-t">
                                         {transactionId}
                                     </span>
-                                    <CopyButton
-                                        onClick={() => ClipboardHelper.copy(
-                                            transactionId
-                                        )}
-                                        buttonType="copy"
-                                    />
+                                    <CopyButton copy={transactionId} />
                                 </div>
                             </div>
                             {includedBlockId && (
@@ -173,12 +167,7 @@ class TransactionPage extends AsyncComponent<RouteComponentProps<TransactionPage
                                                 {includedBlockId}
                                             </Link>
                                         </span>
-                                        <CopyButton
-                                            onClick={() => ClipboardHelper.copy(
-                                                includedBlockId
-                                            )}
-                                            buttonType="copy"
-                                        />
+                                        <CopyButton copy={includedBlockId} />
                                     </div>
                                 </div>
                             )}


### PR DESCRIPTION
# Description of change

- Truncated outputId in Output component (better view in associated outputs and landing)
- Added copy button for output id
- Added optional prop to Output that can be used to display full output ids
- Truncated bech32 addresses nested in Output
- Adjusted scss in Associated outputs and Input/Output components
- Simplified CopyButton code (remove annoying "Copied" message)

Aims to complete https://github.com/iotaledger/explorer/issues/448

## Type of change

- Enhancement (a non-breaking change which adds functionality)
