### PR TITLE
Feat: Add feed re-connect probe

### DIFF
--- a/client/src/app/components/stardust/Feeds.tsx
+++ b/client/src/app/components/stardust/Feeds.tsx
@@ -343,7 +343,11 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
      */
     private setupFeedLivenessProbe(): void {
         this._feedProbeTimerId = setInterval(() => {
-            const msSinceLast = Date.now() - this._lastUpdateItems!!;
+            if (!this._lastUpdateItems) {
+                this._lastUpdateItems = Date.now();
+            }
+
+            const msSinceLast = Date.now() - this._lastUpdateItems;
 
             if (this._lastUpdateItems && msSinceLast > this.FEER_PROBE_THRESHOLD) {
                 this.closeItems();
@@ -351,7 +355,7 @@ abstract class Feeds<P extends RouteComponentProps<{ network: string }>, S exten
 
                 this.initNetworkServices();
             }
-        }, this.FEER_PROBE_THRESHOLD)
+        }, this.FEER_PROBE_THRESHOLD);
     }
 }
 


### PR DESCRIPTION
# Description of change

- Add a probe (setInterval) to check for feed being disconnected, if detected it will reset the feed subscription.

This covers the case when on machine sleep, the feed stops streaming with no disconnect event. Now it will resume after 1,5 sec.

Aim to complete https://github.com/iotaledger/explorer/issues/446

## Type of change

- Enhancement (a non-breaking change which adds functionality)

