### PR TITLE
Fix(client): Fix navigating to base client route

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -23,17 +23,22 @@ const App: React.FC<RouteComponentProps<AppRouteProps> & { config: IConfiguratio
     { history, match: { params: { network, action } }, config: { identityResolverEnabled } }
 ) => {
     const [networks, setNetworks] = useState<INetwork[]>([]);
+    const [networksLoaded, setNetworksLoaded] = useState(false);
 
     useEffect(() => {
         const networkService = ServiceFactory.get<NetworkService>("network");
         const networkConfigs = networkService.networks();
+
         setNetworks(networkConfigs);
+        setNetworksLoaded(true);
     }, []);
 
-    if (!network) {
-        network = networks.length > 0 ? networks[0].network : MAINNET;
-        history.replace(`/${network}`);
-    }
+    useEffect(() => {
+        if (networksLoaded && !network) {
+            network = networks.length > 0 ? networks[0].network : MAINNET;
+            history.replace(`/${network}`);
+        }
+    }, [networksLoaded]);
 
     const networkConfig = networks.find(n => n.network === network);
 


### PR DESCRIPTION
# Description of change

-  Make first available network config load properly when navigating to base client route

Aims to fix https://github.com/iotaledger/explorer/issues/492

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
