### PR TITLE
Fix: GitHub workflows updated to latest node and npm versions

### DIFF
--- a/.github/workflows/api-prod.yaml
+++ b/.github/workflows/api-prod.yaml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: API and GCP Config
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/api-shimmer-prod.yaml
+++ b/.github/workflows/api-shimmer-prod.yaml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: API and GCP Config
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/api-shimmer-staging.yaml
+++ b/.github/workflows/api-shimmer-staging.yaml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: API and GCP Config
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/api-staging.yaml
+++ b/.github/workflows/api-staging.yaml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: API and GCP Config
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/bot-prod.yaml
+++ b/.github/workflows/bot-prod.yaml
@@ -30,12 +30,12 @@ jobs:
             fs.writeFileSync('./discord-bot/src/data/config.prod.json', process.env.CONFIG_JSON)
             fs.writeFileSync('./discord-bot/dispatch.yaml', process.env.DISPATCH_YAML)
             fs.writeFileSync('./discord-bot/app.yaml', process.env.APP_YAML)      
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: Deploy
         run: |
           cd discord-bot

--- a/.github/workflows/client-prod.yaml
+++ b/.github/workflows/client-prod.yaml
@@ -42,12 +42,12 @@ jobs:
           script: |
             const fs = require('fs')
             fs.writeFileSync('./client/src/assets/config/config.prod.json', process.env.CONFIG_JSON)
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: vercel 27
         run: npm install -g vercel@27.4.0
       - name: Client Deploy

--- a/.github/workflows/client-shimmer-prod.yaml
+++ b/.github/workflows/client-shimmer-prod.yaml
@@ -42,12 +42,12 @@ jobs:
           script: |
             const fs = require('fs')
             fs.writeFileSync('./client/public/env.js', `window.env = { API_ENDPOINT: "${process.env.CONFIG_API_URL}" };`)
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: vercel 27
         run: npm install -g vercel@27.4.0
       - name: Client Deploy

--- a/.github/workflows/client-shimmer-staging.yaml
+++ b/.github/workflows/client-shimmer-staging.yaml
@@ -42,12 +42,12 @@ jobs:
           script: |
             const fs = require('fs')
             fs.writeFileSync('./client/public/env.js', `window.env = { API_ENDPOINT: "${process.env.CONFIG_API_URL}" };`)
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
+          node-version: "16.16"
       - name: npm 7
-        run: npm install -g npm@7
+        run: npm install -g npm@8.18
       - name: vercel 27
         run: npm install -g vercel@27.4.0
       - name: Client Deploy

--- a/.github/workflows/client-shimmer-staging.yaml
+++ b/.github/workflows/client-shimmer-staging.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "16.16"
-      - name: npm 7
+      - name: npm 8.18
         run: npm install -g npm@8.18
       - name: vercel 27
         run: npm install -g vercel@27.4.0

--- a/.github/workflows/client-staging.yaml
+++ b/.github/workflows/client-staging.yaml
@@ -42,12 +42,12 @@ jobs:
           script: |
             const fs = require('fs')
             fs.writeFileSync('./client/src/assets/config/config.staging.json', process.env.CONFIG_JSON)
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
-      - name: npm 7
-        run: npm install -g npm@7
+          node-version: "16.16"
+      - name: npm 8.18
+        run: npm install -g npm@8.18
       - name: vercel 27
         run: npm install -g vercel@27.4.0
       - name: Client Deploy


### PR DESCRIPTION
# Description of change

- Updated shimmer client staging workflow to use Node version 16.16.
- Updated shimmer client staging workflow to use Npm version 8.18.
- Updated shimmer api staging workflow to use Node version 16.16.
- Updated shimmer api staging workflow to use Npm version 8.18.

Aims to fix https://github.com/iotaledger/explorer/issues/490

## Type of change

- Enhancement (a non-breaking change which adds functionality)
