### PR TITLE
Fix: Css of storage rent when it is zero

### DIFF
--- a/client/src/app/routes/stardust/AddressPage.tsx
+++ b/client/src/app/routes/stardust/AddressPage.tsx
@@ -167,7 +167,7 @@ class AddressPage extends AsyncComponent<RouteComponentProps<AddressRouteProps>,
                                                 )}
                                             </div>
                                         </div>
-                                        {storageRentBalance && (
+                                        {storageRentBalance ?
                                             <div className="section--data margin-t-m">
                                                 <div className="label">
                                                     Storage rent
@@ -189,8 +189,7 @@ class AddressPage extends AsyncComponent<RouteComponentProps<AddressRouteProps>,
                                                     </span>
                                                     <CopyButton copy={String(storageRentBalance)} />
                                                 </div>
-                                            </div>
-                                        )}
+                                            </div> : ""}
                                     </div>
                                     {outputResponse && outputResponse.length === 0 && (
                                         <div className="section">


### PR DESCRIPTION
# Description of change

- Display nothing when storage rent is zero on Address Page.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

Aims to fix https://github.com/iotaledger/explorer/issues/505
