### PR TITLE
Fix: Disable click on tag in Tagged data payload

### DIFF
--- a/client/src/app/components/stardust/TaggedDataPayload.tsx
+++ b/client/src/app/components/stardust/TaggedDataPayload.tsx
@@ -55,7 +55,6 @@ class TaggedDataPayload extends Component<TaggedDataPayloadProps, TaggedDataPayl
                     </div>
                     <DataToggle
                         sourceData={hexIndex}
-                        link={`/${network}/indexed/${payload.tag}`}
                         withSpacedHex={true}
                     />
 


### PR DESCRIPTION
# Description of change

- Disable click on tag in Tagged data payload on block page.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
