### PR TITLE
Fix: Prevent fetching IBM Plex mono font and Material icons from google

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
             "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@fontsource/ibm-plex-mono": "^4.5.12",
+                "@fontsource/material-icons": "^4.5.4",
                 "@iota/crypto.js": "^1.8.6",
                 "@iota/crypto.js-stardust": "npm:@iota/crypto.js@^2.0.0-rc.1",
                 "@iota/iota.js": "^1.8.6",
@@ -2460,6 +2462,16 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@fontsource/ibm-plex-mono": {
+            "version": "4.5.12",
+            "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-4.5.12.tgz",
+            "integrity": "sha512-ysF4GfudxLgDnpycjzrHFKqsEMOYHt0IUJN6dRECg6YLvVggLMj/SPh+w0QWjdgXkIbjqIbcho0O5mNcLCJMiQ=="
+        },
+        "node_modules/@fontsource/material-icons": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
+            "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.10.4",
@@ -23098,6 +23110,16 @@
                     "dev": true
                 }
             }
+        },
+        "@fontsource/ibm-plex-mono": {
+            "version": "4.5.12",
+            "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-4.5.12.tgz",
+            "integrity": "sha512-ysF4GfudxLgDnpycjzrHFKqsEMOYHt0IUJN6dRECg6YLvVggLMj/SPh+w0QWjdgXkIbjqIbcho0O5mNcLCJMiQ=="
+        },
+        "@fontsource/material-icons": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
+            "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.10.4",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,8 @@
         "test": "craco test"
     },
     "dependencies": {
+        "@fontsource/ibm-plex-mono": "^4.5.12",
+        "@fontsource/material-icons": "^4.5.4",
         "@iota/crypto.js": "^1.8.6",
         "@iota/crypto.js-stardust": "npm:@iota/crypto.js@^2.0.0-rc.1",
         "@iota/iota.js": "^1.8.6",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,10 +21,6 @@
     <title>Shimmer Explorer</title>
     <link href="https://webassets.iota.org/fonts/css/inter.css" rel="stylesheet" type="text/css" media="all">
     <link href="https://webassets.iota.org/fonts/css/metropolis.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,600;1,400;1,600&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,7 +5,6 @@ import { BrowserRouter, Route, RouteComponentProps } from "react-router-dom";
 import App from "./app/App";
 import { AppRouteProps } from "./app/AppRouteProps";
 import { ServiceFactory } from "./factories/serviceFactory";
-import "./index.scss";
 import { IConfiguration } from "./models/config/IConfiguration";
 import { CHRYSALIS, STARDUST } from "./models/config/protocolVersion";
 import { ChrysalisApiClient } from "./services/chrysalis/chrysalisApiClient";
@@ -21,6 +20,9 @@ import { SettingsService } from "./services/settingsService";
 import { StardustApiClient } from "./services/stardust/stardustApiClient";
 import { StardustFeedClient } from "./services/stardust/stardustFeedClient";
 import { StardustTangleCacheService } from "./services/stardust/stardustTangleCacheService";
+import "@fontsource/ibm-plex-mono";
+import "@fontsource/material-icons";
+import "./index.scss";
 
 // Build config
 const identityResolverEnabled = process.env.REACT_APP_IDENTITY_RESOLVER_ENABLED === "true";


### PR DESCRIPTION
# Description of change

- Installed "IBM Plex mono" and "Material icons" as npm package

Fixes https://github.com/iotaledger/explorer/issues/507

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Visually

