### PR TITLE
Feat: Move sec since last milestone ticker to latest entry in the feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 application-data
 .DS_Store
 
+.idea/
 /api/dist
 /api/.env
 /client/build

--- a/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
+++ b/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
@@ -27,11 +27,7 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
     const network = networkConfig.network;
     const secondsSinceLast = useMilestoneInterval(latestMilestoneIndex);
     const secondsSinceLastView = secondsSinceLast ? (
-        <span>
-            <span>(last: </span>
-            <span className="seconds">{secondsSinceLast.toFixed(2)}</span>
-            <span>s)</span>
-        </span>
+        <span className="seconds">{secondsSinceLast.toFixed(2)}s ago</span>
     ) : "";
 
     useEffect(() => {
@@ -43,7 +39,8 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
             for (const milestone of milestones) {
                 const milestoneId = milestone.properties?.milestoneId as string;
 
-                if (!milestoneIdToStats.has(milestoneId)) {
+                const msStat = milestoneIdToStats.get(milestoneId);
+                if (!msStat) {
                     const milestoneStats = await stardustTangleCacheService.milestoneStats(
                         networkConfig.network, milestoneId
                     );
@@ -61,7 +58,12 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
     }, [milestones]);
 
     const milestonesWithStats: IFeedItem[] = [];
+    let highestIndex = 0;
     for (const milestone of milestones) {
+        const msIndex = milestone.properties?.index as number;
+        if (msIndex > highestIndex) {
+            highestIndex = msIndex;
+        }
         const milestoneId = milestone.properties?.milestoneId as string;
         if (milestoneIdToStats.has(milestoneId)) {
             milestonesWithStats.push(milestone);
@@ -74,7 +76,7 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
     return (
         <>
             <div className="section--header milestone-feed-header row padding-l-8">
-                <h2>Latest milestones</h2>{secondsSinceLastView}
+                <h2>Latest milestones</h2>
             </div>
             <div className="feed-items">
                 <div className="row feed-item--header ms-feed">
@@ -138,11 +140,11 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
                                     <Tooltip
                                         tooltipContent={tooltipContent}
                                     >
-                                        {ago}
+                                        {index === highestIndex ? secondsSinceLastView : ago}
                                     </Tooltip>
                                 </span>
                                 <span className="feed-item--value ms-timestamp mobile">
-                                    {tooltipContent} ({ago})
+                                    {tooltipContent} ({index === highestIndex ? secondsSinceLastView : ago})
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
# Description of change

Moves "last milestone ticker"  from the feed title to the latest milestone in the feed. This means that the ticker is also not visible until the frontend has fetched at least one milestone.

Aka:

https://user-images.githubusercontent.com/1385611/199050803-6f9f557c-2c2f-45cc-b67c-4c01510fd2ae.mov


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Local development instance.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
