### PR TITLE
Fix: Permanode check when retrieving milestone stats

### DIFF
--- a/api/src/routes/stardust/milestone/stats/get.ts
+++ b/api/src/routes/stardust/milestone/stats/get.ts
@@ -39,6 +39,10 @@ export async function get(
     if (currentMilesoneStats[request.milestoneId]?.blocksCount) {
         stats = currentMilesoneStats[request.milestoneId];
     } else {
+        if (!networkConfig.permaNodeEndpoint) {
+            return {};
+        }
+
         const chronicleService = ServiceFactory.get<ChronicleService>(
             `chronicle-${networkConfig.network}`
         );

--- a/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
+++ b/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
@@ -95,8 +95,8 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
                     const milestoneId = milestone.properties?.milestoneId as string;
                     const milestoneIdShort = `${milestoneId.slice(0, 6)}....${milestoneId.slice(-6)}`;
                     const timestamp = milestone.properties?.timestamp as number * 1000;
-                    const includedBlocks = milestoneIdToStats.get(milestoneId)?.blocksCount ?? "";
-                    const txs = milestoneIdToStats.get(milestoneId)?.perPayloadType?.txPayloadCount ?? "";
+                    const includedBlocks = milestoneIdToStats.get(milestoneId)?.blocksCount ?? "-";
+                    const txs = milestoneIdToStats.get(milestoneId)?.perPayloadType?.txPayloadCount ?? "-";
                     const ago = moment(timestamp).fromNow();
                     const tooltipContent = DateHelper.formatShort(timestamp);
 


### PR DESCRIPTION
# Description of change

Check if permanode is configured when retrieving milestone stats.
fixes #603  .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
