### PR TITLE
Fix: Tooltip cutoff on mobile

### DIFF
--- a/client/src/app/components/stardust/statistics/ChartTooltip.tsx
+++ b/client/src/app/components/stardust/statistics/ChartTooltip.tsx
@@ -22,11 +22,16 @@ const ChartTooltip: React.FC<ChartTooltipProps> = ({ tooltipRef }) => {
 
     const getX = () => {
         let x = position.x + 8;
-        const remainingWidth = window.innerWidth - (position.x + 20);
+        const tooltipWidth = tooltipRef.current?.offsetWidth ?? 0;
+        const remainingWidthRight = window.innerWidth - (position.x + 20);
+        const remainingWidthLeft = position.x;
 
-        if (tooltipRef.current && remainingWidth <= tooltipRef.current.offsetWidth) {
-            x = position.x - tooltipRef.current.offsetWidth;
+        if (remainingWidthRight <= tooltipWidth && remainingWidthLeft <= tooltipWidth) {
+            x = position.x - (tooltipWidth / 2);
+        } else if (remainingWidthRight <= tooltipWidth) {
+            x = position.x - tooltipWidth;
         }
+
         return x;
     };
 


### PR DESCRIPTION
# Description of change

Align chart tooltip center and cursor pointer if the tooltip cant fit on either left or right of the cursor pointer and edge of the screen on mobile.  
 fixes #619 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
