### PR TITLE
Fix: Replace avg. addresses graph with Total addresses per day

### DIFF
--- a/api/src/models/influx/IInfluxDbCache.ts
+++ b/api/src/models/influx/IInfluxDbCache.ts
@@ -1,5 +1,5 @@
 import {
-    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IAvgAddressesPerMilestoneDailyInflux,
+    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IActiveAddressesDailyInflux,
     IBlocksDailyInflux, ILedgerSizeDailyInflux, INftActivityDailyInflux, IOutputsDailyInflux,
     IStorageDepositDailyInflux, ITokensHeldPerOutputDailyInflux, ITokensHeldWithUnlockConditionDailyInflux,
     ITokensTransferredDailyInflux, ITransactionsDailyInflux, IUnclaimedGenesisOutputsDailyInflux,
@@ -25,7 +25,7 @@ export interface IInfluxDbCache {
     outputsDaily: Map<DayKey, IOutputsDailyInflux>;
     tokensHeldDaily: Map<DayKey, ITokensHeldPerOutputDailyInflux>;
     addressesWithBalanceDaily: Map<DayKey, IAddressesWithBalanceDailyInflux>;
-    avgAddressesPerMilestoneDaily: Map<DayKey, IAvgAddressesPerMilestoneDailyInflux>;
+    activeAddressesDaily: Map<DayKey, IActiveAddressesDailyInflux>;
     tokensTransferredDaily: Map<DayKey, ITokensTransferredDailyInflux>;
     aliasActivityDaily: Map<DayKey, IAliasActivityDailyInflux>;
     unlockConditionsPerTypeDaily: Map<DayKey, IUnlockConditionsPerTypeDailyInflux>;
@@ -46,7 +46,7 @@ export const CACHE_INIT = {
     outputsDaily: new Map(),
     tokensHeldDaily: new Map(),
     addressesWithBalanceDaily: new Map(),
-    avgAddressesPerMilestoneDaily: new Map(),
+    activeAddressesDaily: new Map(),
     tokensTransferredDaily: new Map(),
     aliasActivityDaily: new Map(),
     unlockConditionsPerTypeDaily: new Map(),

--- a/api/src/models/influx/IInfluxTimedEntries.ts
+++ b/api/src/models/influx/IInfluxTimedEntries.ts
@@ -34,9 +34,8 @@ export type IAddressesWithBalanceDailyInflux = ITimedEntry & {
     addressesWithBalance: number | null;
 };
 
-export type IAvgAddressesPerMilestoneDailyInflux = ITimedEntry & {
-    addressesReceiving: number | null;
-    addressesSending: number | null;
+export type IActiveAddressesDailyInflux = ITimedEntry & {
+    activeAddresses: number | null;
 };
 
 export type ITokensTransferredDailyInflux = ITimedEntry & {

--- a/api/src/routes/stardust/analytics/influx/get.ts
+++ b/api/src/routes/stardust/analytics/influx/get.ts
@@ -2,7 +2,7 @@ import { ServiceFactory } from "../../../../factories/serviceFactory";
 import { INetworkBoundGetRequest } from "../../../../models/api/stardust/INetworkBoundGetRequest";
 import { IConfiguration } from "../../../../models/configuration/IConfiguration";
 import {
-    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IAvgAddressesPerMilestoneDailyInflux,
+    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IActiveAddressesDailyInflux,
     IBlocksDailyInflux, ILedgerSizeDailyInflux, INftActivityDailyInflux, IOutputsDailyInflux,
     IStorageDepositDailyInflux, ITokensHeldPerOutputDailyInflux, ITokensHeldWithUnlockConditionDailyInflux,
     ITokensTransferredDailyInflux, ITransactionsDailyInflux, IUnclaimedGenesisOutputsDailyInflux,
@@ -22,7 +22,7 @@ export interface IDailyAnalyticsResponse {
     outputsDaily?: IOutputsDailyInflux[];
     tokensHeldDaily?: ITokensHeldPerOutputDailyInflux[];
     addressesWithBalanceDaily?: IAddressesWithBalanceDailyInflux[];
-    avgAddressesPerMilestoneDaily?: IAvgAddressesPerMilestoneDailyInflux[];
+    activeAddressesDaily?: IActiveAddressesDailyInflux[];
     tokensTransferredDaily?: ITokensTransferredDailyInflux[];
     aliasActivityDaily?: IAliasActivityDailyInflux[];
     unlockConditionsPerTypeDaily?: IUnlockConditionsPerTypeDailyInflux[];
@@ -56,7 +56,7 @@ export async function get(
         outputsDaily: influxService.outputsDaily,
         tokensHeldDaily: influxService.tokensHeldDaily,
         addressesWithBalanceDaily: influxService.addressesWithBalanceDaily,
-        avgAddressesPerMilestoneDaily: influxService.avgAddressesPerMilestoneDaily,
+        activeAddressesDaily: influxService.activeAddressesDaily,
         tokensTransferredDaily: influxService.tokensTransferredDaily,
         aliasActivityDaily: influxService.aliasActivityDaily,
         unlockConditionsPerTypeDaily: influxService.unlockConditionsPerTypeDaily,

--- a/api/src/services/stardust/influx/influxDbClient.ts
+++ b/api/src/services/stardust/influx/influxDbClient.ts
@@ -5,7 +5,7 @@ import {
     CACHE_INIT, DayKey, DAY_KEY_FORMAT, IInfluxDbCache
 } from "../../../models/influx/IInfluxDbCache";
 import {
-    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IAvgAddressesPerMilestoneDailyInflux,
+    IAddressesWithBalanceDailyInflux, IAliasActivityDailyInflux, IActiveAddressesDailyInflux,
     IBlocksDailyInflux, ILedgerSizeDailyInflux, INftActivityDailyInflux, IOutputsDailyInflux,
     IStorageDepositDailyInflux, ITimedEntry, ITokensHeldPerOutputDailyInflux, ITokensHeldWithUnlockConditionDailyInflux,
     ITokensTransferredDailyInflux, ITransactionsDailyInflux, IUnclaimedGenesisOutputsDailyInflux,
@@ -13,7 +13,7 @@ import {
 } from "../../../models/influx/IInfluxTimedEntries";
 import {
     ADDRESSES_WITH_BALANCE_DAILY_QUERY, ALIAS_ACTIVITY_DAILY_QUERY,
-    AVG_ACTIVE_ADDRESSES_PER_MILESTONE_DAILY_QUERY, BLOCK_DAILY_QUERY,
+    TOTAL_ACTIVE_ADDRESSES_DAILY_QUERY, BLOCK_DAILY_QUERY,
     LEDGER_SIZE_DAILY_QUERY, NFT_ACTIVITY_DAILY_QUERY, OUTPUTS_DAILY_QUERY,
     STORAGE_DEPOSIT_DAILY_QUERY,
     TOKENS_HELD_BY_OUTPUTS_DAILY_QUERY, TOKENS_HELD_WITH_UC_DAILY_QUERY,
@@ -67,7 +67,7 @@ export abstract class InfluxDbClient {
 
     /**
      * Build a new client instance asynchronously.
-     * @returns Boolean rapresenting that the client ping succeeded.
+     * @returns Boolean representing that the client ping succeeded.
      */
     public async buildClient(): Promise<boolean> {
         const protocol = "https";
@@ -169,10 +169,10 @@ export abstract class InfluxDbClient {
             this._cache.addressesWithBalanceDaily,
             "Addresses with balance Daily"
         );
-        this.updateCacheEntry<IAvgAddressesPerMilestoneDailyInflux>(
-            AVG_ACTIVE_ADDRESSES_PER_MILESTONE_DAILY_QUERY,
-            this._cache.avgAddressesPerMilestoneDaily,
-            "Avarage addresses with balance Daily"
+        this.updateCacheEntry<IActiveAddressesDailyInflux>(
+            TOTAL_ACTIVE_ADDRESSES_DAILY_QUERY,
+            this._cache.activeAddressesDaily,
+            "Number of Daily Active Addresses"
         );
         this.updateCacheEntry<ITokensTransferredDailyInflux>(
             TOKENS_TRANSFERRED_DAILY_QUERY,

--- a/api/src/services/stardust/influx/influxDbService.ts
+++ b/api/src/services/stardust/influx/influxDbService.ts
@@ -35,9 +35,9 @@ export class InfluxDBService extends InfluxDbClient {
         );
     }
 
-    public get avgAddressesPerMilestoneDaily() {
+    public get activeAddressesDaily() {
         return this.mapToSortedValuesArray(
-            this._cache.avgAddressesPerMilestoneDaily
+            this._cache.activeAddressesDaily
         );
     }
 

--- a/api/src/services/stardust/influx/influxQueries.ts
+++ b/api/src/services/stardust/influx/influxQueries.ts
@@ -98,19 +98,17 @@ export const ADDRESSES_WITH_BALANCE_DAILY_QUERY = {
     `
 };
 
-export const AVG_ACTIVE_ADDRESSES_PER_MILESTONE_DAILY_QUERY = {
+export const TOTAL_ACTIVE_ADDRESSES_DAILY_QUERY = {
     full: `
         SELECT
-            mean("receiving_count") AS "addressesReceiving",
-            mean("sending_count") AS "addressesSending"
-        FROM "stardust_address_activity"
+            last("count") AS activeAddresses
+        FROM "stardust_daily_active_addresses"
         GROUP BY time(1d) fill(null)
     `,
     parameterized: `
         SELECT
-            mean("receiving_count") AS "addressesReceiving",
-            mean("sending_count") AS "addressesSending"
-        FROM "stardust_address_activity"
+            last("count") AS activeAddresses
+        FROM "stardust_daily_active_addresses"
         WHERE time >= $from and time <= $to
         GROUP BY time(1d) fill(null)
     `

--- a/client/src/app/routes/stardust/statistics/StatisticsPage.tsx
+++ b/client/src/app/routes/stardust/statistics/StatisticsPage.tsx
@@ -31,7 +31,7 @@ const StatisticsPage: React.FC<RouteComponentProps<StatisticsPageProps>> = ({ ma
     const [outputs, setOutputs] = useState<DataPoint[]>([]);
     const [tokensHeld, setTokensHeld] = useState<DataPoint[]>([]);
     const [addressesWithBalance, setAddressesWithBalance] = useState<DataPoint[]>([]);
-    const [avgAddressesPerMilestone, setAvgAddressesPerMilestone] = useState<DataPoint[]>([]);
+    const [activeAddresses, setActiveAddresses] = useState<DataPoint[]>([]);
     const [tokensTransferred, setTokensTransferred] = useState<DataPoint[]>([]);
     const [aliasActivity, setAliasActivity] = useState<DataPoint[]>([]);
     const [unlockConditionsPerType, setUnlockConditionsPerType] = useState<DataPoint[]>([]);
@@ -54,7 +54,7 @@ const StatisticsPage: React.FC<RouteComponentProps<StatisticsPageProps>> = ({ ma
                 setOutputs(graphsData.outputsDaily);
                 setTokensHeld(graphsData.tokensHeldDaily);
                 setAddressesWithBalance(graphsData.addressesWithBalanceDaily);
-                setAvgAddressesPerMilestone(graphsData.avgAddressesPerMilestoneDaily);
+                setActiveAddresses(graphsData.activeAddresses);
                 setTokensTransferred(graphsData.tokensTransferredDaily);
                 setAliasActivity(graphsData.aliasActivityDaily);
                 setUnlockConditionsPerType(graphsData.unlockConditionsPerTypeDaily);
@@ -162,12 +162,11 @@ const StatisticsPage: React.FC<RouteComponentProps<StatisticsPageProps>> = ({ ma
                                     color="#00F5DD"
                                     data={addressesWithBalance}
                                 />
-                                <StackedLineChart
-                                    title="Avg. Number of Active Addresses per Milestone"
-                                    subgroups={["sending", "receiving"]}
-                                    groupLabels={["Sending", "Receiving"]}
-                                    colors={["#4140DF", "#36A1AC"]}
-                                    data={avgAddressesPerMilestone}
+                                <LineChart
+                                    title="Number of Daily Active Addresses"
+                                    label="Addresses"
+                                    color="#00F5DD"
+                                    data={activeAddresses}
                                 />
                             </div>
                             <div className="row statistics-row">

--- a/client/src/helpers/stardust/statisticsUtils.ts
+++ b/client/src/helpers/stardust/statisticsUtils.ts
@@ -7,7 +7,7 @@ export interface IStatisticsGraphsData {
     outputsDaily: DataPoint[];
     tokensHeldDaily: DataPoint[];
     addressesWithBalanceDaily: DataPoint[];
-    avgAddressesPerMilestoneDaily: DataPoint[];
+    activeAddresses: DataPoint[];
     tokensTransferredDaily: DataPoint[];
     aliasActivityDaily: DataPoint[];
     unlockConditionsPerTypeDaily: DataPoint[];
@@ -61,10 +61,9 @@ export function mapDailyStatsToGraphsData(data: IInfluxDailyResponse): IStatisti
             time: moment(entry.time).add(1, "minute").unix(),
             n: entry.addressesWithBalance ?? 0
         })) ?? [],
-        avgAddressesPerMilestoneDaily: data.avgAddressesPerMilestoneDaily?.map(day => ({
+        activeAddresses: data.activeAddressesDaily?.map(day => ({
             time: moment(day.time).add(1, "minute").unix(),
-            sending: day.addressesSending ?? 0,
-            receiving: day.addressesReceiving ?? 0
+            n: day.activeAddresses ?? 0
         })) ?? [],
         tokensTransferredDaily: data.tokensTransferredDaily?.map(day => ({
             time: moment(day.time).add(1, "minute").unix(),

--- a/client/src/models/api/stardust/influx/IInfluxDailyResponse.ts
+++ b/client/src/models/api/stardust/influx/IInfluxDailyResponse.ts
@@ -35,10 +35,9 @@ export interface IAddressesWithBalanceDailyInflux {
     addressesWithBalance: number | null;
 }
 
-export interface IAvgAddressesPerMilestoneDailyInflux {
+export interface IActiveAddressesDailyInflux {
     time: Date;
-    addressesReceiving: number | null;
-    addressesSending: number | null;
+    activeAddresses: number | null;
 }
 
 export interface ITokensTransferredDailyInflux {
@@ -102,7 +101,7 @@ export interface IInfluxDailyResponse extends IResponse {
     outputsDaily?: IOutputsDailyInflux[];
     tokensHeldDaily?: ITokensHeldPerOutputDailyInflux[];
     addressesWithBalanceDaily?: IAddressesWithBalanceDailyInflux[];
-    avgAddressesPerMilestoneDaily?: IAvgAddressesPerMilestoneDailyInflux[];
+    activeAddressesDaily?: IActiveAddressesDailyInflux[];
     tokensTransferredDaily?: ITokensTransferredDailyInflux[];
     aliasActivityDaily?: IAliasActivityDailyInflux[];
     unlockConditionsPerTypeDaily?: IUnlockConditionsPerTypeDailyInflux[];


### PR DESCRIPTION
# Description of change

Replace avg. active addresses per milestone graph with total active addresses per day
fixes #615 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
