### PR TITLE
chore: Update query for LockedStorage deposit (total) stat

### DIFF
--- a/api/src/services/stardust/influx/influxQueries.ts
+++ b/api/src/services/stardust/influx/influxQueries.ts
@@ -298,18 +298,9 @@ export const NFT_STAT_TOTAL_QUERY = `
     FROM "stardust_ledger_outputs";
 `;
 
-export const BYTE_PROTOCOL_PARAMS_QUERY = `
-     SELECT
-         last("v_byte_cost") AS byteCost,
-         last("v_byte_factor_data") AS factorData,
-         last("v_byte_factor_key") AS factorKey
-     FROM "stardust_protocol_params";
-`;
-
-export const KEY_DATA_BYTES_QUERY = `
+export const STORAGE_DEPOSIT_TOTAL_QUERY = `
     SELECT
-        last("total_data_bytes") AS bytesData,
-        last("total_key_bytes") AS bytesKey
+        last("total_storage_deposit_value") * 100 AS "lockedStorageDeposit"
     FROM "stardust_ledger_size";
 `;
 


### PR DESCRIPTION
# Description of change

- Remove the computation that account for byte cost from the Locked storage stat, and just simply take the query result from one query.

Resolves https://github.com/iotaledger/explorer/issues/627

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
