### PR TITLE
Fix: Align Visualizer stats to top of the page [mobile]

### DIFF
--- a/client/src/app/routes/stardust/Visualizer.scss
+++ b/client/src/app/routes/stardust/Visualizer.scss
@@ -102,10 +102,46 @@
         text-align: right;
       }
       .card--label {
-          justify-content: flex-end;
+        justify-content: flex-end;
       }
       .card--content {
-          padding: 20px 30px;
+         padding: 20px 30px;
+      }
+    }
+
+    @include tablet-down {
+      top: 60px;
+      left: 20px;
+      bottom: auto;
+      justify-content: left;
+
+      .stats-panel {
+        .card--value,
+        .card--label {
+          text-align: left;
+        }
+        .card--label {
+          justify-content: flex-start;
+        }
+        .card--content {
+          padding: 0;
+        }
+        .stats-panel__info{
+          padding: 0 10px;
+          display: inline-block;
+        }
+      }
+    }
+
+    @include phone-down {
+      .stats-panel {
+        .card--value,
+        .card--label {
+          font-size: 12px;
+        }
+        .stats-panel__info:last-of-type{
+          display: block;
+        }
       }
     }
   }

--- a/client/src/app/routes/stardust/Visualizer.tsx
+++ b/client/src/app/routes/stardust/Visualizer.tsx
@@ -249,17 +249,23 @@ class Visualizer extends Feeds<RouteComponentProps<VisualizerRouteProps>, Visual
                 <div className="stats-panel-container">
                     <div className="card stats-panel">
                         <div className="card--content">
-                            <div className="card--label">Blocks</div>
-                            <div className="card--value">
-                                {itemCount}
+                            <div className="stats-panel__info">
+                                <div className="card--label">Blocks</div>
+                                <div className="card--value">
+                                    {itemCount}
+                                </div>
                             </div>
-                            <div className="card--label">BPS / CBPS</div>
-                            <div className="card--value">
-                                {itemsPerSecond} / {confirmedItemsPerSecond}
+                            <div className="stats-panel__info">
+                                <div className="card--label">BPS / CBPS</div>
+                                <div className="card--value">
+                                    {itemsPerSecond} / {confirmedItemsPerSecond}
+                                </div>
                             </div>
-                            <div className="card--label">Referenced Rate</div>
-                            <div className="card--value">
-                                {confirmedItemsPerSecondPercent}
+                            <div className="stats-panel__info">
+                                <div className="card--label">Referenced Rate</div>
+                                <div className="card--value">
+                                    {confirmedItemsPerSecondPercent}
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
# Description of change

Align Visualizer stats to top of the page to be in line with the Pause button
needed for #646 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
