### PR TITLE
Feat: Balance section improvements on Address page

### DIFF
--- a/client/src/app/components/chrysalis/QR.scss
+++ b/client/src/app/components/chrysalis/QR.scss
@@ -1,6 +1,7 @@
 @import "../../../scss/fonts";
 @import "../../../scss/variables";
 @import "../../../scss/mixins";
+@import "../../../scss/media-queries";
 
 .qr-container {
     display: flex;
@@ -15,5 +16,20 @@
         font-weight: 600;
         text-align: center;
         margin-top: 24px;
+    }
+
+    svg {
+        @include desktop-down {
+            width: 80px;
+            height: 80px;
+        }
+    }
+
+    @include desktop-down {
+        width: 80px;
+    }
+
+    @include phone-down {
+        width: 180px;
     }
 }

--- a/client/src/app/components/stardust/AddressBalance.scss
+++ b/client/src/app/components/stardust/AddressBalance.scss
@@ -68,6 +68,8 @@
 
                 .material-icons {
                     font-size: 18px;
+                    color: #b0bfd9;
+                    padding-left: 5px;
                 }
             }
         }
@@ -84,6 +86,10 @@
                 }
             }
         }
+    }
+
+    @include phone-down {
+        justify-content: center;
     }
 }
 

--- a/client/src/app/components/stardust/AddressBalance.scss
+++ b/client/src/app/components/stardust/AddressBalance.scss
@@ -12,18 +12,63 @@
         display: flex;
 
         .balance {
-            &:first-child {
-                margin-right: 32px;
+            display: flex;
+            flex-direction: row;
+            
+            .icon {
+                align-self: center;
             }
 
-            span {
+            &:not(:last-child) {
+                margin-right: 40px;
+
+                @include tablet-down {
+                    margin-right: 0px;
+                }
+            }
+
+            .balance-value {
+                display: flex;
+                flex-direction: column;
+
+                @include tablet-down {
+                    flex-direction: row;
+                }
+
+                .balance-value--inline {
+                    @include tablet-down {
+                        margin-left: 5px;
+                    }
+                }
+            }
+
+            .balance-smr, .balance-fiat {
                 color: #b0bfd9;
-                font-size: 20px;
-                padding-left: 10px;
+                font-size: 18px;
+
+                @include phone-down {
+                    font-size: 14px;
+                }
+            }
+
+            &:first-child {
+                .balance-smr {
+                    color: #000;
+                }
+
+                .balance-value--inline {
+                    span {
+                        color: #000;
+                    }
+                }
             }
 
             .balance-heading {
                 height: 20px;
+
+                .material-icons {
+                    font-size: 18px;
+                }
             }
         }
     }
@@ -33,8 +78,9 @@
             flex-direction: column;
 
             .balance {
-                &:last-child {
+                &:not(:first-child) {
                     margin-top: 12px;
+                    margin-left: 56px;
                 }
             }
         }

--- a/client/src/app/components/stardust/AddressBalance.tsx
+++ b/client/src/app/components/stardust/AddressBalance.tsx
@@ -44,7 +44,7 @@ const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalan
         <div className="balance">
             {showWallet && <Icon icon="wallet" boxed />}
             <div>
-                <div className="row balance-heading">
+                <div className="row middle balance-heading">
                     <div className="label">{label}</div>
                     {showInfo &&
                         <Tooltip tooltipContent={CONDITIONAL_BALANCE_INFO}>
@@ -98,6 +98,14 @@ const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalan
                             false,
                             true
                         )}
+                        {buildBalanceView(
+                            "Conditionally Locked Balance",
+                            conditionalBalance,
+                            formatConditionalBalanceFull,
+                            setFormatConditionalBalanceFull,
+                            true,
+                            false
+                        )}
                         {storageRentBalance &&
                             buildBalanceView(
                                 "Storage Deposit",
@@ -107,14 +115,6 @@ const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalan
                                 false,
                                 false
                             )}
-                        {buildBalanceView(
-                            "Conditionally Locked Balance",
-                            conditionalBalance,
-                            formatConditionalBalanceFull,
-                            setFormatConditionalBalanceFull,
-                            true,
-                            false
-                        )}
                     </React.Fragment>
                 ) : (
                     <React.Fragment>

--- a/client/src/app/components/stardust/AddressBalance.tsx
+++ b/client/src/app/components/stardust/AddressBalance.tsx
@@ -18,54 +18,63 @@ interface AddressBalanceProps {
      * The trivially unlockable portion of the balance, fetched from chronicle.
      */
     spendableBalance?: number;
+    /**
+     * The storage rent balance.
+     */
+    storageRentBalance?: number;
 }
 
 const CONDITIONAL_BALANCE_INFO =
-"These funds reside within outputs with additional unlock conditions which might be potentially un-lockable";
+    "These funds reside within outputs with additional unlock conditions which might be potentially un-lockable";
 
-const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalance }) => {
+const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalance, storageRentBalance }) => {
     const { name: network, tokenInfo } = useContext(NetworkContext);
     const [formatBalanceFull, setFormatBalanceFull] = useState(false);
     const [formatConditionalBalanceFull, setFormatConditionalBalanceFull] = useState(false);
+    const [formatStorageBalanceFull, setFormatStorageBalanceFull] = useState(false);
 
     const buildBalanceView = (
         label: string,
         amount: number,
         isFormatFull: boolean,
         setIsFormatFull: React.Dispatch<React.SetStateAction<boolean>>,
-        showInfo: boolean
+        showInfo: boolean,
+        showWallet: boolean
     ) => (
         <div className="balance">
-            <div className="row balance-heading">
-                <div className="label">{label}</div>
-                {showInfo &&
-                <Tooltip tooltipContent={CONDITIONAL_BALANCE_INFO}>
-                    <span className="material-icons">
-                        info
-                    </span>
-                </Tooltip>}
-            </div>
-            <div className="value featured">
-                {amount > 0 ? (
-                    <div>
-                        <div className="row middle">
-                            <span
-                                onClick={() => setIsFormatFull(!isFormatFull)}
-                                className="pointer margin-r-5"
-                            >
-                                {formatAmount(amount, tokenInfo, isFormatFull)}
+            {showWallet && <Icon icon="wallet" boxed />}
+            <div>
+                <div className="row balance-heading">
+                    <div className="label">{label}</div>
+                    {showInfo &&
+                        <Tooltip tooltipContent={CONDITIONAL_BALANCE_INFO}>
+                            <span className="material-icons">
+                                info
                             </span>
-                            <CopyButton copy={String(amount)} />
+                        </Tooltip>}
+                </div>
+                <div className="value featured">
+                    {amount > 0 ? (
+                        <div className="balance-value middle">
+                            <div className="row middle">
+                                <span
+                                    onClick={() => setIsFormatFull(!isFormatFull)}
+                                    className="balance-smr pointer margin-r-5"
+                                >
+                                    {formatAmount(amount, tokenInfo, isFormatFull)}
+                                </span>
+                                <CopyButton copy={String(amount)} />
+                            </div>
+                            {isMarketed && (
+                                <div className="balance-value--inline">
+                                    <span>(</span>
+                                    <FiatValue classNames="balance-fiat" value={amount} />
+                                    <span>)</span>
+                                </div>
+                            )}
                         </div>
-                        {isMarketed && (
-                            <React.Fragment>
-                                <span>(</span>
-                                <FiatValue value={amount} />
-                                <span>)</span>
-                            </React.Fragment>
-                        )}
-                    </div>
-                ) : <span className="margin-r-5">0</span>}
+                    ) : <span className="margin-r-5">0</span>}
+                </div>
             </div>
         </div>
     );
@@ -78,39 +87,61 @@ const AddressBalance: React.FC<AddressBalanceProps> = ({ balance, spendableBalan
 
     return (
         <div className="row middle balance-wrapper">
-            <Icon icon="wallet" boxed />
             <div className="balance-wrapper--inner">
                 {shouldShowExtendedBalance ? (
                     <React.Fragment>
                         {buildBalanceView(
-                            "Spendable Balance",
+                            "Available Balance",
                             spendableBalance,
                             formatBalanceFull,
                             setFormatBalanceFull,
-                            false
+                            false,
+                            true
                         )}
+                        {storageRentBalance &&
+                            buildBalanceView(
+                                "Storage Deposit",
+                                storageRentBalance,
+                                formatStorageBalanceFull,
+                                setFormatStorageBalanceFull,
+                                false,
+                                false
+                            )}
                         {buildBalanceView(
                             "Conditionally Locked Balance",
                             conditionalBalance,
                             formatConditionalBalanceFull,
                             setFormatConditionalBalanceFull,
-                            true
+                            true,
+                            false
                         )}
                     </React.Fragment>
                 ) : (
-                    buildBalanceView(
-                        "Balance",
-                        balance,
-                        formatBalanceFull,
-                        setFormatBalanceFull,
-                        false
-                    )
+                    <React.Fragment>
+                        {buildBalanceView(
+                            "Balance",
+                            balance,
+                            formatBalanceFull,
+                            setFormatBalanceFull,
+                            false,
+                            true
+                        )}
+                        {storageRentBalance &&
+                            buildBalanceView(
+                                "Storage Deposit",
+                                storageRentBalance,
+                                formatStorageBalanceFull,
+                                setFormatStorageBalanceFull,
+                                false,
+                                false
+                            )}
+                    </React.Fragment>
                 )}
             </div>
         </div>
     );
 };
 
-AddressBalance.defaultProps = { spendableBalance: undefined };
+AddressBalance.defaultProps = { spendableBalance: undefined, storageRentBalance: undefined };
 
 export default AddressBalance;

--- a/client/src/app/components/stardust/Bech32Address.tsx
+++ b/client/src/app/components/stardust/Bech32Address.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode } from "react";
 import { Bech32AddressProps } from "../Bech32AddressProps";
 import CopyButton from "../CopyButton";
+import TruncatedId from "./TruncatedId";
 
 /**
  * Component which will display an Bech32Address.
@@ -11,9 +12,6 @@ class Bech32Address extends Component<Bech32AddressProps> {
      * @returns The node to render.
      */
     public render(): ReactNode {
-        const truncatedAddress =
-            `${this.props.addressDetails?.bech32?.slice(0, 7)}...${this.props.addressDetails?.bech32?.slice(-7)}`;
-
         return (
             <div className="bech32-address">
                 {this.props.addressDetails?.bech32 && (
@@ -32,11 +30,11 @@ class Bech32Address extends Component<Bech32AddressProps> {
                                         `/${this.props.network}/addr/${this.props.addressDetails?.bech32}`
                                     )}
                                 >
-                                    {this.props.truncateAddress ? truncatedAddress : this.props.addressDetails.bech32}
+                                    <TruncatedId id={this.props.addressDetails.bech32} />
                                 </button>
                             )}
                             {!this.props.history && (
-                                <span className="margin-r-t">{this.props.addressDetails.bech32}</span>
+                                <TruncatedId id={this.props.addressDetails.bech32} />
                             )}
                             {this.props.showCopyButton && <CopyButton copy={this.props.addressDetails?.bech32} />}
                         </div>
@@ -56,11 +54,11 @@ class Bech32Address extends Component<Bech32AddressProps> {
                                         `/${this.props.network}/addr/${this.props.addressDetails?.hex}`
                                     )}
                                 >
-                                    {this.props.addressDetails?.hex}
+                                    <TruncatedId id={this.props.addressDetails?.hex} />
                                 </button>
                             )}
                             {!this.props.history && (
-                                <span className="margin-r-t">{this.props.addressDetails?.hex}</span>
+                                <TruncatedId id={this.props.addressDetails?.hex} />
                             )}
                             <CopyButton copy={this.props.addressDetails?.hex} />
                         </div>

--- a/client/src/app/routes/stardust/AddressPage.scss
+++ b/client/src/app/routes/stardust/AddressPage.scss
@@ -240,8 +240,28 @@
   }
 
   .general-content {
-    @include tablet-down {
+    .section--data {
+      @include tablet-down {
+        max-width: 80%;
+      }
+
+      @include phone-down {
+        max-width: 100%;
+      }
+    }
+
+    @include phone-down {
       flex-direction: column;
+    }
+  }
+
+  .qr-content {
+    @include tablet-down {
+      align-self: flex-end;
+    }
+
+    @include phone-down {
+      align-self: center;
     }
   }
 }

--- a/client/src/app/routes/stardust/AddressPage.tsx
+++ b/client/src/app/routes/stardust/AddressPage.tsx
@@ -198,7 +198,7 @@ const AddressPage: React.FC<RouteComponentProps<AddressRouteProps>> = (
                                                 />
                                             )}
                                         </div>
-                                        <div className="section--data">
+                                        <div className="section--data qr-content">
                                             {bech32AddressDetails?.bech32 && (
                                                 //  eslint-disable-next-line react/jsx-pascal-case
                                                 <QR data={bech32AddressDetails.bech32} />

--- a/client/src/app/routes/stardust/AddressPage.tsx
+++ b/client/src/app/routes/stardust/AddressPage.tsx
@@ -10,12 +10,10 @@ import { useIsMounted } from "../../../helpers/hooks/useIsMounted";
 import { PromiseStatus } from "../../../helpers/promise/promiseMonitor";
 import { Bech32AddressHelper } from "../../../helpers/stardust/bech32AddressHelper";
 import { TransactionsHelper } from "../../../helpers/stardust/transactionsHelper";
-import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import { IBech32AddressDetails } from "../../../models/api/IBech32AddressDetails";
 import { STARDUST } from "../../../models/config/protocolVersion";
 import { StardustTangleCacheService } from "../../../services/stardust/stardustTangleCacheService";
 import QR from "../../components/chrysalis/QR";
-import CopyButton from "../../components/CopyButton";
 import TabbedSection from "../../components/hoc/TabbedSection";
 import Modal from "../../components/Modal";
 import Spinner from "../../components/Spinner";
@@ -51,7 +49,7 @@ const AddressPage: React.FC<RouteComponentProps<AddressRouteProps>> = (
     { location, match: { params: { network, address } } }
 ) => {
     const isMounted = useIsMounted();
-    const { tokenInfo, bech32Hrp, rentStructure } = useContext(NetworkContext);
+    const { bech32Hrp, rentStructure } = useContext(NetworkContext);
     const [tangleCacheService] = useState(
         ServiceFactory.get<StardustTangleCacheService>(`tangle-cache-${STARDUST}`)
     );
@@ -64,7 +62,6 @@ const AddressPage: React.FC<RouteComponentProps<AddressRouteProps>> = (
     const [addressBasicOutputs, isBasicOutputsLoading] = useAddressBasicOutputs(network, bech32AddressDetails?.bech32);
     const [addressAliasOutputs, isAliasOutputsLoading] = useAddressAliasOutputs(network, bech32AddressDetails?.bech32);
     const [addressNftOutputs, isNftOutputsLoading] = useAddressNftOutputs(network, bech32AddressDetails?.bech32);
-    const [isFormatStorageRentFull, setIsFormatStorageRentFull] = useState<boolean>(false);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
     const [tokensCount, setTokenCount] = useState<number>(0);
@@ -197,6 +194,7 @@ const AddressPage: React.FC<RouteComponentProps<AddressRouteProps>> = (
                                                 <AddressBalance
                                                     balance={balance}
                                                     spendableBalance={sigLockedBalance}
+                                                    storageRentBalance={storageRentBalance}
                                                 />
                                             )}
                                         </div>
@@ -207,30 +205,6 @@ const AddressPage: React.FC<RouteComponentProps<AddressRouteProps>> = (
                                             )}
                                         </div>
                                     </div>
-                                    {storageRentBalance && (
-                                        <div className="section--data margin-t-m">
-                                            <div className="label">
-                                                Storage deposit
-                                            </div>
-                                            <div className="row middle value featured">
-                                                <span
-                                                    onClick={() => {
-                                                        if (isMounted) {
-                                                            setIsFormatStorageRentFull(!isFormatStorageRentFull);
-                                                        }
-                                                    }}
-                                                    className="pointer margin-r-5"
-                                                >
-                                                    {formatAmount(
-                                                        storageRentBalance,
-                                                        tokenInfo,
-                                                        isFormatStorageRentFull
-                                                    )}
-                                                </span>
-                                                <CopyButton copy={String(storageRentBalance)} />
-                                            </div>
-                                        </div>
-                                    )}
                                 </div>
                                 <TabbedSection
                                     tabsEnum={ADDRESS_PAGE_TABS}


### PR DESCRIPTION
# Description of change

- Make storage balance inline with spendable and conditional balance for desktop screen.
- Display balances vertically for smaller screens with fiat value inline.

Resolves https://github.com/iotaledger/explorer/issues/634

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
