### PR TITLE
Fix: Compute txid on message page for chrysalis.

### DIFF
--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -157,14 +157,14 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
                                 </div>
                             </div>
 
-                            {this.state.paramMessageId !== this.state.actualMessageId && (
+                            {this.state.transactionId && (
                                 <div className="section--data">
                                     <div className="label">
                                         Transaction Id
                                     </div>
                                     <div className="value value__secondary row middle">
-                                        <span className="margin-r-t">{this.state.paramMessageId}</span>
-                                        <CopyButton copy={this.state.paramMessageId} />
+                                        <span className="margin-r-t">{this.state.transactionId}</span>
+                                        <CopyButton copy={this.state.transactionId} />
                                     </div>
                                 </div>
                             )}
@@ -425,6 +425,7 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
             this.props.match.params.network, messageId);
 
         if (result?.message) {
+            const message = result.message;
             if (!updateUrl) {
                 window.scrollTo({
                     left: 0,
@@ -434,21 +435,29 @@ class Message extends AsyncComponent<RouteComponentProps<MessageProps>, MessageS
             }
 
             const { inputs, outputs, unlockAddresses, transferTotal } =
-                await TransactionsHelper.getInputsAndOutputs(result?.message,
+                await TransactionsHelper.getInputsAndOutputs(message,
                     this.props.match.params.network,
                     this._bechHrp,
                     this._tangleCacheService);
+            let transactionId;
+
+            if (message.payload?.type === TRANSACTION_PAYLOAD_TYPE) {
+                transactionId = TransactionsHelper.computeTransactionIdFromTransactionPayload(
+                    message.payload
+                );
+            }
+
             this.setState({
                 inputs,
                 outputs,
                 unlockAddresses,
-                transferTotal
+                transferTotal,
+                transactionId
             });
 
             this.setState({
-                paramMessageId: messageId,
                 actualMessageId: result.includedMessageId ?? messageId,
-                message: result.message
+                message
             }, async () => {
                 await this.updateMessageDetails();
             });

--- a/client/src/app/routes/chrysalis/MessageState.ts
+++ b/client/src/app/routes/chrysalis/MessageState.ts
@@ -4,14 +4,14 @@ import { TangleStatus } from "../../../models/tangleStatus";
 
 export interface MessageState {
     /**
-     * The message id that was the parameter.
-     */
-    paramMessageId?: string;
-
-    /**
      * The actual message Id in the case of an included message.
      */
     actualMessageId?: string;
+
+    /**
+     * The transaction id.
+     */
+    transactionId?: string;
 
     /**
      * Message.

--- a/client/src/helpers/chrysalis/transactionsHelper.ts
+++ b/client/src/helpers/chrysalis/transactionsHelper.ts
@@ -1,4 +1,5 @@
-import { Ed25519Address, ED25519_ADDRESS_TYPE, IMessage, IReferenceUnlockBlock, ISignatureUnlockBlock, IUTXOInput, REFERENCE_UNLOCK_BLOCK_TYPE, SIGNATURE_UNLOCK_BLOCK_TYPE, SIG_LOCKED_DUST_ALLOWANCE_OUTPUT_TYPE, SIG_LOCKED_SINGLE_OUTPUT_TYPE, TRANSACTION_PAYLOAD_TYPE } from "@iota/iota.js";
+import { Blake2b } from "@iota/crypto.js";
+import { Ed25519Address, ED25519_ADDRESS_TYPE, IMessage, IReferenceUnlockBlock, ISignatureUnlockBlock, IUTXOInput, REFERENCE_UNLOCK_BLOCK_TYPE, SIGNATURE_UNLOCK_BLOCK_TYPE, SIG_LOCKED_DUST_ALLOWANCE_OUTPUT_TYPE, SIG_LOCKED_SINGLE_OUTPUT_TYPE, TRANSACTION_PAYLOAD_TYPE, serializeTransactionPayload, ITransactionPayload } from "@iota/iota.js";
 import { Converter, WriteStream } from "@iota/util.js";
 import { DateHelper } from "../../helpers/dateHelper";
 import { IBech32AddressDetails } from "../../models/api/IBech32AddressDetails";
@@ -77,7 +78,7 @@ export class TransactionsHelper {
                 let amount = 0;
                 if (transactionResult?.message && transactionResult?.message.payload?.type ===
                     TRANSACTION_PAYLOAD_TYPE) {
-                   amount = transactionResult.message.payload?.essence.outputs[transactionOutputIndex].amount;
+                    amount = transactionResult.message.payload?.essence.outputs[transactionOutputIndex].amount;
                 }
                 inputs.push({
                     ...input,
@@ -132,6 +133,13 @@ export class TransactionsHelper {
             outputs.sort((a, b) => a.index - b.index);
         }
         return { inputs, outputs, unlockAddresses, transferTotal };
+    }
+
+    public static computeTransactionIdFromTransactionPayload(payload: ITransactionPayload) {
+        const tpWriteStream = new WriteStream();
+        serializeTransactionPayload(tpWriteStream, payload);
+
+        return Converter.bytesToHex(Blake2b.sum256(tpWriteStream.finalBytes()));
     }
 
     public static async getMessageStatus(


### PR DESCRIPTION
# Description of change

- Added a helper function to compute transactionId from transactionPayload for chrysalis.
-  Show transactionId on Message page.

Resolves https://github.com/iotaledger/explorer/issues/623

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
