### PR TITLE
Fix: Sort transaction payload inputs and outputs by index

### DIFF
--- a/client/src/helpers/stardust/transactionsHelper.spec.ts
+++ b/client/src/helpers/stardust/transactionsHelper.spec.ts
@@ -1,0 +1,8 @@
+import { TransactionsHelper } from "./transactionsHelper";
+
+describe("Transaction helper", () => {
+    it("should convert little endian encoded hex to big endian", () => {
+        const outputIndex = "0200";
+        expect(TransactionsHelper.convertToBigEndian(outputIndex)).toBe("0002");
+    });
+});

--- a/client/src/helpers/stardust/transactionsHelper.spec.ts
+++ b/client/src/helpers/stardust/transactionsHelper.spec.ts
@@ -5,4 +5,19 @@ describe("Transaction helper", () => {
         const outputIndex = "0200";
         expect(TransactionsHelper.convertToBigEndian(outputIndex)).toBe("0002");
     });
+
+    it("should convert to big endian when the index length is 6", () => {
+        const outputIndex = "9F8601";
+        expect(TransactionsHelper.convertToBigEndian(outputIndex)).toBe("01869F");
+    });
+
+    it("should convert to big endian when the index length is 8", () => {
+        const outputIndex = "9F860101";
+        expect(TransactionsHelper.convertToBigEndian(outputIndex)).toBe("0101869F");
+    });
+
+    it("should convert to big endian if the index has odd length", () => {
+        const outputIndex = "9F86010";
+        expect(TransactionsHelper.convertToBigEndian(outputIndex)).toBe("1060F809");
+    });
 });

--- a/client/src/helpers/stardust/transactionsHelper.ts
+++ b/client/src/helpers/stardust/transactionsHelper.ts
@@ -155,27 +155,28 @@ export class TransactionsHelper {
             }
 
             sortedOutputs = [...outputs, ...remainderOutputs];
-            // Sort outputs in ascending order based on their output index
-            sortedOutputs.sort((a, b) => {
-                const firstOutputIndex = a.id.slice(-4);
-                const secondOutputIndex = b.id.slice(-4);
-                const firstFormattedIndex = TransactionsHelper.convertToBigEndian(firstOutputIndex);
-                const secondFormattedIndex = TransactionsHelper.convertToBigEndian(secondOutputIndex);
-
-                return Number.parseInt(firstFormattedIndex, 16) - Number.parseInt(secondFormattedIndex, 16);
-            });
-            // Sort inputs in ascending order based on their output index
-            inputs.sort((a, b) => {
-                const firstInputIndex = a.outputId.slice(-4);
-                const secondInputIndex = b.outputId.slice(-4);
-                const firstFormattedIndex = TransactionsHelper.convertToBigEndian(firstInputIndex);
-                const secondFormattedIndex = TransactionsHelper.convertToBigEndian(secondInputIndex);
-
-                return Number.parseInt(firstFormattedIndex, 16) - Number.parseInt(secondFormattedIndex, 16);
-            });
+            this.sortInputsAndOuputsByIndex(sortedOutputs);
+            this.sortInputsAndOuputsByIndex(inputs);
         }
 
         return { inputs, unlocks, outputs: sortedOutputs, unlockAddresses, transferTotal };
+    }
+
+    /**
+     * Sort inputs and outputs in assending order by index.
+     * @param items Inputs or Outputs.
+     * @returns Sorted inputs or outputs.
+     */
+    public static sortInputsAndOuputsByIndex(items: IInput[] | IOutput[]) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        items.sort((a: any, b: any) => {
+            const firstIndex: string = a.id ? a.id.slice(-4) : a.outputId.slice(-4);
+            const secondIndex: string = b.id ? b.id.slice(-4) : b.outputId.slice(-4);
+            const firstFormattedIndex = this.convertToBigEndian(firstIndex);
+            const secondFormattedIndex = this.convertToBigEndian(secondIndex);
+
+            return Number.parseInt(firstFormattedIndex, 16) - Number.parseInt(secondFormattedIndex, 16);
+        });
     }
 
     /**

--- a/client/src/helpers/stardust/transactionsHelper.ts
+++ b/client/src/helpers/stardust/transactionsHelper.ts
@@ -165,7 +165,6 @@ export class TransactionsHelper {
     /**
      * Sort inputs and outputs in assending order by index.
      * @param items Inputs or Outputs.
-     * @returns Sorted inputs or outputs.
      */
     public static sortInputsAndOuputsByIndex(items: IInput[] | IOutput[]) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -187,6 +186,12 @@ export class TransactionsHelper {
     public static convertToBigEndian(index: string) {
         const bigEndian = [];
         let hexLength = index.length;
+
+        if (hexLength % 2 !== 0) {
+            index = "0".concat(index);
+            hexLength = index.length;
+        }
+
         while (hexLength >= 0) {
             const slicedBits = index.slice(hexLength - 2, hexLength);
             bigEndian.push(slicedBits);


### PR DESCRIPTION
# Description of change

- Created a function to convert little endian encoded hex to big endian.
- Sort inputs and outputs of transaction payload by index.

Resolves https://github.com/iotaledger/explorer/issues/656

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
