### PR TITLE
Fix: Clickable info icon on disabled tab

### DIFF
--- a/client/src/app/components/hoc/TabbedSection.scss
+++ b/client/src/app/components/hoc/TabbedSection.scss
@@ -72,6 +72,7 @@
             }
 
             .modal button {
+                pointer-events: auto;
                 padding-left: 0;
             }
 

--- a/client/src/app/components/hoc/TabbedSection.tsx
+++ b/client/src/app/components/hoc/TabbedSection.tsx
@@ -85,7 +85,11 @@ const TabbedSection: React.FC<TabbedSectionProps> = ({ tabsEnum, children, tabOp
                         className={classNames("tab-wrapper",
                             { "active": idx === selectedTab },
                             { "disabled": isDisabled })}
-                        onClick={() => setSelectedTab(idx)}
+                        onClick={() => {
+                            if (!isDisabled) {
+                                setSelectedTab(idx);
+                            }
+                        }}
                     >
                         <button
                             className="tab"


### PR DESCRIPTION
# Description of change

Make Info icon clickable on disabled tab
needed for  #652 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
