### PR TITLE
Feat: Make Tabs linkable

### DIFF
--- a/client/src/app/MilestoneFeedAnalytics.tsx
+++ b/client/src/app/MilestoneFeedAnalytics.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { ServiceFactory } from "../factories/serviceFactory";
 import { IMilestoneAnalyticStats } from "../models/api/stats/IMilestoneAnalyticStats";
 import { STARDUST } from "../models/config/protocolVersion";
@@ -8,9 +9,10 @@ import Spinner from "./components/Spinner";
 interface MilestoneFeedAnalyicsProps {
     network: string;
     milestoneIndex: number;
+    blockId: string;
 }
 
-const MilestoneFeedAnalyics: React.FC<MilestoneFeedAnalyicsProps> = ({ network, milestoneIndex }) => {
+const MilestoneFeedAnalyics: React.FC<MilestoneFeedAnalyicsProps> = ({ network, milestoneIndex, blockId }) => {
     const [tangleCacheService] = useState(ServiceFactory.get<StardustTangleCacheService>(`tangle-cache-${STARDUST}`));
     const [milestoneStats, setMilestoneStats] = useState<IMilestoneAnalyticStats | undefined>();
     const [fetching, setFetching] = useState<boolean>(true);
@@ -44,7 +46,14 @@ const MilestoneFeedAnalyics: React.FC<MilestoneFeedAnalyicsProps> = ({ network, 
                 <span className="feed-item--value ms-blocks">
                     {fetching ?
                         <Spinner compact /> :
-                        <div className="feed-item__ms-stat">{includedBlocks ?? "--"}</div>}
+                        <div className="feed-item__ms-stat">
+                            <Link
+                                className="feed-item--hash ms-id"
+                                to={`/${network}/block/${blockId}?tab=RefBlocks`}
+                            >
+                                {includedBlocks ?? "--"}
+                            </Link>
+                        </div>}
                 </span>
             </div>
             <div className="feed-item__content">
@@ -52,7 +61,14 @@ const MilestoneFeedAnalyics: React.FC<MilestoneFeedAnalyicsProps> = ({ network, 
                 <span className="feed-item--value ms-txs">
                     {fetching ?
                         <Spinner compact /> :
-                        <div className="feed-item__ms-stat">{txs ?? "--"}</div>}
+                        <div className="feed-item__ms-stat">
+                            <Link
+                                className="feed-item--hash ms-id"
+                                to={`/${network}/block/${blockId}?tab=RefBlocks`}
+                            >
+                                {txs ?? "--"}
+                            </Link>
+                        </div>}
                 </span>
             </div>
         </React.Fragment>

--- a/client/src/app/components/hoc/TabbedSection.tsx
+++ b/client/src/app/components/hoc/TabbedSection.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
 import Modal from "../Modal";
 import { ModalData } from "../ModalProps";
 import Spinner from "../Spinner";
@@ -57,8 +58,25 @@ interface TabbedSectionProps {
  * @returns The React component TSX.
  */
 const TabbedSection: React.FC<TabbedSectionProps> = ({ tabsEnum, children, tabOptions }) => {
+    const history = useHistory();
+    const location = useLocation();
+    const searchParams = new URLSearchParams(location.search);
     const [selectedTab, setSelectedTab] = useState<number>(0);
     const TABS: string[] = [...Object.values(tabsEnum)];
+
+    useEffect(() => {
+        const tab = searchParams.get("tab");
+        const id = Object.keys(tabsEnum).indexOf(tab ?? "");
+        if (id !== -1) {
+            setSelectedTab(id);
+        }
+      }, [searchParams]);
+
+    const onTabSelected = (id: number) => {
+        const tabParam = new URLSearchParams();
+        tabParam.append("tab", Object.keys(tabsEnum)[id]);
+        history.push({ search: tabParam.toString() });
+    };
 
     const tabsView = (
         <div className="tabbed-section--tabs-wrapper">
@@ -85,7 +103,7 @@ const TabbedSection: React.FC<TabbedSectionProps> = ({ tabsEnum, children, tabOp
                         className={classNames("tab-wrapper",
                             { "active": idx === selectedTab },
                             { "disabled": isDisabled })}
-                        onClick={() => setSelectedTab(idx)}
+                        onClick={() => onTabSelected(idx)}
                     >
                         <button
                             className="tab"

--- a/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
+++ b/client/src/app/routes/stardust/landing/MilestoneFeed.tsx
@@ -87,6 +87,7 @@ const MilestoneFeed: React.FC<MilestoneFeedProps> = ({ networkConfig, milestones
                             <MilestoneFeedAnalyics
                                 network={network}
                                 milestoneIndex={milestone.index}
+                                blockId={blockId}
                             />
                             <div className="feed-item__content">
                                 <span className="feed-item--label">Timestamp</span>


### PR DESCRIPTION
# Description of change

- Make tabs linkable by adding `tab` query to the URL
- Added link from Milestone feed (block/txs numbers) to Referenced Blocks tab on Milestone Block page
 
resolves #659 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
