### PR TITLE
Feat: Add minimal IPFS client and loading flag for NFT metadata uri

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,7 +30,6 @@
                 "d3-shape": "^3.1.0",
                 "d3-time-format": "^4.1.0",
                 "express": "^4.18.1",
-                "ipfs-http-client": "^60.0.0",
                 "jsonschema": "^1.4.1",
                 "moment": "^2.29.4",
                 "qr.js": "0.0.0",
@@ -2004,11 +2003,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "node_modules/@chainsafe/is-ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
-            "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
-        },
         "node_modules/@craco/craco": {
             "version": "7.0.0-alpha.7",
             "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.0.0-alpha.7.tgz",
@@ -2830,44 +2824,6 @@
                 "@iota/checksum": "^1.0.0-beta.30",
                 "@iota/transaction": "^1.0.0-beta.30",
                 "bluebird": "^3.7.2"
-            }
-        },
-        "node_modules/@ipld/dag-cbor": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
-            "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
-            "dependencies": {
-                "cborg": "^1.10.0",
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@ipld/dag-json": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
-            "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
-            "dependencies": {
-                "cborg": "^1.10.0",
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@ipld/dag-pb": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
-            "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
-            "dependencies": {
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -3714,144 +3670,6 @@
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
             "dev": true
         },
-        "node_modules/@libp2p/interface-connection": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
-            "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
-            "dependencies": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "it-stream-types": "^1.0.4",
-                "uint8arraylist": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/interface-keychain": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
-            "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
-            "dependencies": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/interface-peer-id": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-            "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
-            "dependencies": {
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/interface-peer-info": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
-            "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
-            "dependencies": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/interface-pubsub": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
-            "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
-            "dependencies": {
-                "@libp2p/interface-connection": "^3.0.0",
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.0.0",
-                "it-pushable": "^3.0.0",
-                "uint8arraylist": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/interfaces": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-            "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/logger": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
-            "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
-            "dependencies": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "debug": "^4.3.3",
-                "interface-datastore": "^7.0.0",
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@libp2p/peer-id": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.1.tgz",
-            "integrity": "sha512-uGIR4rS+j+IzzIu0kih4MonZEfRmjGNfXaSPMIFOeMxZItZT6TIpxoVNYxHl4YtneSFKzlLnf9yx9EhRcyfy8Q==",
-            "dependencies": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.2.0",
-                "multiformats": "^11.0.0",
-                "uint8arrays": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@multiformats/multiaddr": {
-            "version": "11.4.0",
-            "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
-            "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
-            "dependencies": {
-                "@chainsafe/is-ip": "^2.0.1",
-                "dns-over-http-resolver": "^2.1.0",
-                "err-code": "^3.0.1",
-                "multiformats": "^11.0.0",
-                "uint8arrays": "^4.0.2",
-                "varint": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@multiformats/multiaddr-to-uri": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
-            "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
-            "dependencies": {
-                "@multiformats/multiaddr": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3945,60 +3763,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/@protobufjs/aspromise": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-        },
-        "node_modules/@protobufjs/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-        },
-        "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-        },
-        "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-        },
-        "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
-            }
-        },
-        "node_modules/@protobufjs/float": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-        },
-        "node_modules/@protobufjs/path": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-        },
-        "node_modules/@protobufjs/pool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-        },
-        "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "node_modules/@rollup/plugin-babel": {
             "version": "5.3.1",
@@ -4969,11 +4733,6 @@
             "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
             "dev": true
         },
-        "node_modules/@types/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-        },
         "node_modules/@types/minimist": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -4983,7 +4742,8 @@
         "node_modules/@types/node": {
             "version": "16.11.56",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-            "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A=="
+            "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
+            "dev": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -6116,11 +5876,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/any-signal": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-            "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
-        },
         "node_modules/anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -6719,12 +6474,14 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -6785,18 +6542,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/blob-to-it": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.0.tgz",
-            "integrity": "sha512-O9P902MzxHg8fjIAzmK4HSo9WmcMn1ACJvSHJvIYWDr4na7GLyR5iQTf0i2EXlnM5EIWmWtk+vh38tTph9JiPA==",
-            "dependencies": {
-                "browser-readablestream-to-it": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
             }
         },
         "node_modules/bluebird": {
@@ -6886,6 +6631,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6913,15 +6659,6 @@
             "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
             "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
-        },
-        "node_modules/browser-readablestream-to-it": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.0.tgz",
-            "integrity": "sha512-x7L6NN0FF0LchYKA7D5x2/oJ+n6Y8A0gFaazIxH2AkHr+fjFJvsDUYLLQKAfIkpKiLjQEkbjF0DBw7HRT1ylNA==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
         },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
@@ -7051,6 +6788,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
             "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7098,17 +6836,6 @@
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
             "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
             "dev": true
-        },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
-            }
         },
         "node_modules/bytes": {
             "version": "3.0.0",
@@ -7231,14 +6958,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/cborg": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
-            "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
-            "bin": {
-                "cborg": "cli.js"
             }
         },
         "node_modules/chalk": {
@@ -7541,7 +7260,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/confusing-browser-globals": {
             "version": "1.0.11",
@@ -8387,15 +8107,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/dag-jose": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
-            "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
-            "dependencies": {
-                "@ipld/dag-cbor": "^9.0.0",
-                "multiformats": "^11.0.0"
-            }
-        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8720,21 +8431,6 @@
             "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
             "dev": true
         },
-        "node_modules/dns-over-http-resolver": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
-            "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
-            "dependencies": {
-                "debug": "^4.3.1",
-                "native-fetch": "^4.0.2",
-                "receptacle": "^1.3.2",
-                "undici": "^5.12.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/dns-packet": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
@@ -8916,17 +8612,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/electron-fetch": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
-            "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
-            "dependencies": {
-                "encoding": "^0.1.13"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/electron-to-chromium": {
             "version": "1.4.233",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz",
@@ -9000,6 +8685,8 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
             }
@@ -9068,11 +8755,6 @@
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
-        },
-        "node_modules/err-code": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-            "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
@@ -10260,11 +9942,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "node_modules/fast-fifo": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-            "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
-        },
         "node_modules/fast-glob": {
             "version": "3.2.11",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -10885,11 +10562,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/get-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-            "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
         },
         "node_modules/get-own-enumerable-property-symbols": {
             "version": "3.0.2",
@@ -11538,6 +11210,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "devOptional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -11579,6 +11252,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11701,40 +11375,6 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
-        "node_modules/interface-datastore": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
-            "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
-            "dependencies": {
-                "interface-store": "^3.0.0",
-                "nanoid": "^4.0.0",
-                "uint8arrays": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/interface-datastore/node_modules/nanoid": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-            "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
-            "bin": {
-                "nanoid": "bin/nanoid.js"
-            },
-            "engines": {
-                "node": "^14 || ^16 || >=18"
-            }
-        },
-        "node_modules/interface-store": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
-            "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -11764,181 +11404,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/ipfs-core-types": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.0.tgz",
-            "integrity": "sha512-qO1xVO3n5m7scTXXtMz8hDTLdwXInnwqadIDQpXC446BIlaYyRWUvLcFQ2bOjQql9/CPNTaPHzjzr5Y1XxqpJw==",
-            "dependencies": {
-                "@ipld/dag-pb": "^4.0.0",
-                "@libp2p/interface-keychain": "^2.0.0",
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interface-peer-info": "^1.0.2",
-                "@libp2p/interface-pubsub": "^3.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "@types/node": "^18.0.0",
-                "interface-datastore": "^7.0.0",
-                "ipfs-unixfs": "^9.0.0",
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/ipfs-core-types/node_modules/@types/node": {
-            "version": "18.14.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-            "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A=="
-        },
-        "node_modules/ipfs-core-utils": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.0.tgz",
-            "integrity": "sha512-7N/KfsOPGJu9mwN8EQwrW9HXgS5RNM3WUyjIMWk49KlpYmsXectXuC9i6npI1vn1W/oUaIOZt3lHx37jecnepw==",
-            "dependencies": {
-                "@libp2p/logger": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "@multiformats/multiaddr-to-uri": "^9.0.1",
-                "any-signal": "^3.0.0",
-                "blob-to-it": "^2.0.0",
-                "browser-readablestream-to-it": "^2.0.0",
-                "err-code": "^3.0.1",
-                "ipfs-core-types": "^0.14.0",
-                "ipfs-unixfs": "^9.0.0",
-                "ipfs-utils": "^9.0.13",
-                "it-all": "^2.0.0",
-                "it-map": "^2.0.0",
-                "it-peekable": "^2.0.0",
-                "it-to-stream": "^1.0.0",
-                "merge-options": "^3.0.4",
-                "multiformats": "^11.0.0",
-                "nanoid": "^4.0.0",
-                "parse-duration": "^1.0.0",
-                "timeout-abort-controller": "^3.0.0",
-                "uint8arrays": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/ipfs-core-utils/node_modules/nanoid": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-            "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
-            "bin": {
-                "nanoid": "bin/nanoid.js"
-            },
-            "engines": {
-                "node": "^14 || ^16 || >=18"
-            }
-        },
-        "node_modules/ipfs-http-client": {
-            "version": "60.0.0",
-            "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-60.0.0.tgz",
-            "integrity": "sha512-d6Rqc1UP5nWhp7j0PumK80CA5LvbTvskro+qGw7hgWvbfQ0rX/5ddig7ELvVYJbJM4YBxCJSaSHDEOGoSpzzKg==",
-            "dependencies": {
-                "@ipld/dag-cbor": "^9.0.0",
-                "@ipld/dag-json": "^10.0.0",
-                "@ipld/dag-pb": "^4.0.0",
-                "@libp2p/logger": "^2.0.0",
-                "@libp2p/peer-id": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "any-signal": "^3.0.0",
-                "dag-jose": "^4.0.0",
-                "err-code": "^3.0.1",
-                "ipfs-core-types": "^0.14.0",
-                "ipfs-core-utils": "^0.18.0",
-                "ipfs-utils": "^9.0.13",
-                "it-first": "^2.0.0",
-                "it-last": "^2.0.0",
-                "merge-options": "^3.0.4",
-                "multiformats": "^11.0.0",
-                "parse-duration": "^1.0.0",
-                "stream-to-it": "^0.2.2",
-                "uint8arrays": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/ipfs-unixfs": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
-            "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
-            "dependencies": {
-                "err-code": "^3.0.1",
-                "protobufjs": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/ipfs-utils": {
-            "version": "9.0.14",
-            "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
-            "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
-            "dependencies": {
-                "any-signal": "^3.0.0",
-                "browser-readablestream-to-it": "^1.0.0",
-                "buffer": "^6.0.1",
-                "electron-fetch": "^1.7.2",
-                "err-code": "^3.0.1",
-                "is-electron": "^2.2.0",
-                "iso-url": "^1.1.5",
-                "it-all": "^1.0.4",
-                "it-glob": "^1.0.1",
-                "it-to-stream": "^1.0.0",
-                "merge-options": "^3.0.4",
-                "nanoid": "^3.1.20",
-                "native-fetch": "^3.0.0",
-                "node-fetch": "^2.6.8",
-                "react-native-fetch-api": "^3.0.0",
-                "stream-to-it": "^0.2.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/ipfs-utils/node_modules/browser-readablestream-to-it": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-            "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
-        },
-        "node_modules/ipfs-utils/node_modules/it-all": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-            "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
-        },
-        "node_modules/ipfs-utils/node_modules/native-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-            "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-            "peerDependencies": {
-                "node-fetch": "*"
-            }
-        },
-        "node_modules/ipfs-utils/node_modules/node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
             }
         },
         "node_modules/is-arguments": {
@@ -12069,11 +11534,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-electron": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-            "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -12362,14 +11822,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
-        "node_modules/iso-url": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
-            "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -12473,91 +11925,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/it-all": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-            "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-first": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
-            "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-glob": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
-            "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
-            "dependencies": {
-                "@types/minimatch": "^3.0.4",
-                "minimatch": "^3.0.4"
-            }
-        },
-        "node_modules/it-last": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.0.tgz",
-            "integrity": "sha512-u0GHZ01tWYtPvDkOaqZSLLWjFv3IJw9cPL9mbEV7wnE8DOsbVoXIuKpnz3U6pySl5RzPVjTzSHOc961ZYttBxg==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
-            "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-peekable": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.0.tgz",
-            "integrity": "sha512-+eacms2jr2wQqIRxU25eqWPHaEeR4IurrS9hTScmCJpWagRkC8WHw7atciEA6KArOiyxHCAXg5Q5We7/RhvqAQ==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-pushable": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-            "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-stream-types": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
-            "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/it-to-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
-            "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "fast-fifo": "^1.0.0",
-                "get-iterator": "^1.0.2",
-                "p-defer": "^3.0.0",
-                "p-fifo": "^1.0.0",
-                "readable-stream": "^3.6.0"
             }
         },
         "node_modules/jake": {
@@ -15083,11 +14450,6 @@
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "dev": true
         },
-        "node_modules/long": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-            "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -15316,25 +14678,6 @@
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
         },
-        "node_modules/merge-options": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-            "dependencies": {
-                "is-plain-obj": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/merge-options/node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -15522,6 +14865,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -15575,32 +14919,16 @@
                 "multicast-dns": "cli.js"
             }
         },
-        "node_modules/multiformats": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
-            "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
             "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/native-fetch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-            "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-            "peerDependencies": {
-                "undici": "*"
             }
         },
         "node_modules/natural-compare": {
@@ -16234,23 +15562,6 @@
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
             "dev": true
         },
-        "node_modules/p-defer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-            "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-fifo": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-            "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-            "dependencies": {
-                "fast-fifo": "^1.0.0",
-                "p-defer": "^3.0.0"
-            }
-        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16341,11 +15652,6 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/parse-duration": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.2.tgz",
-            "integrity": "sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg=="
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -18007,29 +17313,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
-        "node_modules/protobufjs": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-            "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18460,14 +17743,6 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
-        "node_modules/react-native-fetch-api": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
-            "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
-            "dependencies": {
-                "p-defer": "^3.0.0"
-            }
-        },
         "node_modules/react-refresh": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -18799,14 +18074,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/receptacle": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-            "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
         "node_modules/recursive-readdir": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -19115,11 +18382,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/retimer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-            "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
         },
         "node_modules/retry": {
             "version": "0.13.1",
@@ -19950,22 +19212,6 @@
                 "xtend": "^4.0.2"
             }
         },
-        "node_modules/stream-to-it": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-            "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-            "dependencies": {
-                "get-iterator": "^1.0.2"
-            }
-        },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -20793,14 +20039,6 @@
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true
         },
-        "node_modules/timeout-abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-            "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-            "dependencies": {
-                "retimer": "^3.0.0"
-            }
-        },
         "node_modules/timers-browserify": {
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -21092,30 +20330,6 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/uint8arraylist": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
-            "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
-            "dependencies": {
-                "uint8arrays": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/uint8arrays": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-            "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-            "dependencies": {
-                "multiformats": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -21129,17 +20343,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/undici": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-            "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-            "dependencies": {
-                "busboy": "^1.6.0"
-            },
-            "engines": {
-                "node": ">=12.18"
             }
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -21381,11 +20584,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
             "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
-        },
-        "node_modules/varint": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -23769,11 +22967,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "@chainsafe/is-ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
-            "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
-        },
         "@craco/craco": {
             "version": "7.0.0-alpha.7",
             "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.0.0-alpha.7.tgz",
@@ -24370,32 +23563,6 @@
                 "@iota/checksum": "^1.0.0-beta.30",
                 "@iota/transaction": "^1.0.0-beta.30",
                 "bluebird": "^3.7.2"
-            }
-        },
-        "@ipld/dag-cbor": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
-            "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
-            "requires": {
-                "cborg": "^1.10.0",
-                "multiformats": "^11.0.0"
-            }
-        },
-        "@ipld/dag-json": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
-            "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
-            "requires": {
-                "cborg": "^1.10.0",
-                "multiformats": "^11.0.0"
-            }
-        },
-        "@ipld/dag-pb": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
-            "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
-            "requires": {
-                "multiformats": "^11.0.0"
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -25046,104 +24213,6 @@
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
             "dev": true
         },
-        "@libp2p/interface-connection": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
-            "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
-            "requires": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "it-stream-types": "^1.0.4",
-                "uint8arraylist": "^2.1.2"
-            }
-        },
-        "@libp2p/interface-keychain": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
-            "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
-            "requires": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "multiformats": "^11.0.0"
-            }
-        },
-        "@libp2p/interface-peer-id": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-            "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
-            "requires": {
-                "multiformats": "^11.0.0"
-            }
-        },
-        "@libp2p/interface-peer-info": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
-            "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
-            "requires": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0"
-            }
-        },
-        "@libp2p/interface-pubsub": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
-            "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
-            "requires": {
-                "@libp2p/interface-connection": "^3.0.0",
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.0.0",
-                "it-pushable": "^3.0.0",
-                "uint8arraylist": "^2.1.2"
-            }
-        },
-        "@libp2p/interfaces": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-            "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
-        },
-        "@libp2p/logger": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
-            "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
-            "requires": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "debug": "^4.3.3",
-                "interface-datastore": "^7.0.0",
-                "multiformats": "^11.0.0"
-            }
-        },
-        "@libp2p/peer-id": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.1.tgz",
-            "integrity": "sha512-uGIR4rS+j+IzzIu0kih4MonZEfRmjGNfXaSPMIFOeMxZItZT6TIpxoVNYxHl4YtneSFKzlLnf9yx9EhRcyfy8Q==",
-            "requires": {
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interfaces": "^3.2.0",
-                "multiformats": "^11.0.0",
-                "uint8arrays": "^4.0.2"
-            }
-        },
-        "@multiformats/multiaddr": {
-            "version": "11.4.0",
-            "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
-            "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
-            "requires": {
-                "@chainsafe/is-ip": "^2.0.1",
-                "dns-over-http-resolver": "^2.1.0",
-                "err-code": "^3.0.1",
-                "multiformats": "^11.0.0",
-                "uint8arrays": "^4.0.2",
-                "varint": "^6.0.0"
-            }
-        },
-        "@multiformats/multiaddr-to-uri": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
-            "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
-            "requires": {
-                "@multiformats/multiaddr": "^11.0.0"
-            }
-        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -25194,60 +24263,6 @@
                     "dev": true
                 }
             }
-        },
-        "@protobufjs/aspromise": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-        },
-        "@protobufjs/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-        },
-        "@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-        },
-        "@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-        },
-        "@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-            "requires": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
-            }
-        },
-        "@protobufjs/float": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-        },
-        "@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-        },
-        "@protobufjs/path": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-        },
-        "@protobufjs/pool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-        },
-        "@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "@rollup/plugin-babel": {
             "version": "5.3.1",
@@ -26009,11 +25024,6 @@
             "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
             "dev": true
         },
-        "@types/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-        },
         "@types/minimist": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -26023,7 +25033,8 @@
         "@types/node": {
             "version": "16.11.56",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-            "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A=="
+            "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
+            "dev": true
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -26852,11 +25863,6 @@
                 "color-convert": "^1.9.0"
             }
         },
-        "any-signal": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-            "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
-        },
         "anymatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -27327,12 +26333,14 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
         },
         "batch": {
             "version": "0.6.1",
@@ -27368,14 +26376,6 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
-        },
-        "blob-to-it": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.0.tgz",
-            "integrity": "sha512-O9P902MzxHg8fjIAzmK4HSo9WmcMn1ACJvSHJvIYWDr4na7GLyR5iQTf0i2EXlnM5EIWmWtk+vh38tTph9JiPA==",
-            "requires": {
-                "browser-readablestream-to-it": "^2.0.0"
-            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -27456,6 +26456,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -27480,11 +26481,6 @@
             "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
             "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
-        },
-        "browser-readablestream-to-it": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.0.tgz",
-            "integrity": "sha512-x7L6NN0FF0LchYKA7D5x2/oJ+n6Y8A0gFaazIxH2AkHr+fjFJvsDUYLLQKAfIkpKiLjQEkbjF0DBw7HRT1ylNA=="
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -27586,6 +26582,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
             "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -27613,14 +26610,6 @@
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
             "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
             "dev": true
-        },
-        "busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "requires": {
-                "streamsearch": "^1.1.0"
-            }
         },
         "bytes": {
             "version": "3.0.0",
@@ -27706,11 +26695,6 @@
             "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
             "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
             "dev": true
-        },
-        "cborg": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
-            "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
         },
         "chalk": {
             "version": "2.4.2",
@@ -27961,7 +26945,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "confusing-browser-globals": {
             "version": "1.0.11",
@@ -28568,15 +27553,6 @@
                 "d3-time": "1 - 3"
             }
         },
-        "dag-jose": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
-            "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
-            "requires": {
-                "@ipld/dag-cbor": "^9.0.0",
-                "multiformats": "^11.0.0"
-            }
-        },
         "damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -28833,17 +27809,6 @@
             "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
             "dev": true
         },
-        "dns-over-http-resolver": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
-            "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
-            "requires": {
-                "debug": "^4.3.1",
-                "native-fetch": "^4.0.2",
-                "receptacle": "^1.3.2",
-                "undici": "^5.12.0"
-            }
-        },
         "dns-packet": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
@@ -28981,14 +27946,6 @@
                 "jake": "^10.8.5"
             }
         },
-        "electron-fetch": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
-            "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
-            "requires": {
-                "encoding": "^0.1.13"
-            }
-        },
         "electron-to-chromium": {
             "version": "1.4.233",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz",
@@ -29052,6 +28009,8 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "iconv-lite": "^0.6.2"
             }
@@ -29096,11 +28055,6 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
             "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
             "dev": true
-        },
-        "err-code": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-            "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -29983,11 +28937,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "fast-fifo": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-            "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
-        },
         "fast-glob": {
             "version": "3.2.11",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -30442,11 +29391,6 @@
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.3"
             }
-        },
-        "get-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-            "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
         },
         "get-own-enumerable-property-symbols": {
             "version": "3.0.2",
@@ -30942,6 +29886,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "devOptional": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
@@ -30971,7 +29916,8 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
         },
         "ignore": {
             "version": "5.2.0",
@@ -31049,28 +29995,6 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
-        "interface-datastore": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
-            "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
-            "requires": {
-                "interface-store": "^3.0.0",
-                "nanoid": "^4.0.0",
-                "uint8arrays": "^4.0.2"
-            },
-            "dependencies": {
-                "nanoid": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-                    "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
-                }
-            }
-        },
-        "interface-store": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
-            "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
-        },
         "internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -31092,148 +30016,6 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
             "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
             "dev": true
-        },
-        "ipfs-core-types": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.0.tgz",
-            "integrity": "sha512-qO1xVO3n5m7scTXXtMz8hDTLdwXInnwqadIDQpXC446BIlaYyRWUvLcFQ2bOjQql9/CPNTaPHzjzr5Y1XxqpJw==",
-            "requires": {
-                "@ipld/dag-pb": "^4.0.0",
-                "@libp2p/interface-keychain": "^2.0.0",
-                "@libp2p/interface-peer-id": "^2.0.0",
-                "@libp2p/interface-peer-info": "^1.0.2",
-                "@libp2p/interface-pubsub": "^3.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "@types/node": "^18.0.0",
-                "interface-datastore": "^7.0.0",
-                "ipfs-unixfs": "^9.0.0",
-                "multiformats": "^11.0.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "18.14.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-                    "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A=="
-                }
-            }
-        },
-        "ipfs-core-utils": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.0.tgz",
-            "integrity": "sha512-7N/KfsOPGJu9mwN8EQwrW9HXgS5RNM3WUyjIMWk49KlpYmsXectXuC9i6npI1vn1W/oUaIOZt3lHx37jecnepw==",
-            "requires": {
-                "@libp2p/logger": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "@multiformats/multiaddr-to-uri": "^9.0.1",
-                "any-signal": "^3.0.0",
-                "blob-to-it": "^2.0.0",
-                "browser-readablestream-to-it": "^2.0.0",
-                "err-code": "^3.0.1",
-                "ipfs-core-types": "^0.14.0",
-                "ipfs-unixfs": "^9.0.0",
-                "ipfs-utils": "^9.0.13",
-                "it-all": "^2.0.0",
-                "it-map": "^2.0.0",
-                "it-peekable": "^2.0.0",
-                "it-to-stream": "^1.0.0",
-                "merge-options": "^3.0.4",
-                "multiformats": "^11.0.0",
-                "nanoid": "^4.0.0",
-                "parse-duration": "^1.0.0",
-                "timeout-abort-controller": "^3.0.0",
-                "uint8arrays": "^4.0.2"
-            },
-            "dependencies": {
-                "nanoid": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-                    "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
-                }
-            }
-        },
-        "ipfs-http-client": {
-            "version": "60.0.0",
-            "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-60.0.0.tgz",
-            "integrity": "sha512-d6Rqc1UP5nWhp7j0PumK80CA5LvbTvskro+qGw7hgWvbfQ0rX/5ddig7ELvVYJbJM4YBxCJSaSHDEOGoSpzzKg==",
-            "requires": {
-                "@ipld/dag-cbor": "^9.0.0",
-                "@ipld/dag-json": "^10.0.0",
-                "@ipld/dag-pb": "^4.0.0",
-                "@libp2p/logger": "^2.0.0",
-                "@libp2p/peer-id": "^2.0.0",
-                "@multiformats/multiaddr": "^11.0.0",
-                "any-signal": "^3.0.0",
-                "dag-jose": "^4.0.0",
-                "err-code": "^3.0.1",
-                "ipfs-core-types": "^0.14.0",
-                "ipfs-core-utils": "^0.18.0",
-                "ipfs-utils": "^9.0.13",
-                "it-first": "^2.0.0",
-                "it-last": "^2.0.0",
-                "merge-options": "^3.0.4",
-                "multiformats": "^11.0.0",
-                "parse-duration": "^1.0.0",
-                "stream-to-it": "^0.2.2",
-                "uint8arrays": "^4.0.2"
-            }
-        },
-        "ipfs-unixfs": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
-            "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
-            "requires": {
-                "err-code": "^3.0.1",
-                "protobufjs": "^7.0.0"
-            }
-        },
-        "ipfs-utils": {
-            "version": "9.0.14",
-            "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
-            "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
-            "requires": {
-                "any-signal": "^3.0.0",
-                "browser-readablestream-to-it": "^1.0.0",
-                "buffer": "^6.0.1",
-                "electron-fetch": "^1.7.2",
-                "err-code": "^3.0.1",
-                "is-electron": "^2.2.0",
-                "iso-url": "^1.1.5",
-                "it-all": "^1.0.4",
-                "it-glob": "^1.0.1",
-                "it-to-stream": "^1.0.0",
-                "merge-options": "^3.0.4",
-                "nanoid": "^3.1.20",
-                "native-fetch": "^3.0.0",
-                "node-fetch": "^2.6.8",
-                "react-native-fetch-api": "^3.0.0",
-                "stream-to-it": "^0.2.2"
-            },
-            "dependencies": {
-                "browser-readablestream-to-it": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-                    "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
-                },
-                "it-all": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-                    "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
-                },
-                "native-fetch": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-                    "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-                    "requires": {}
-                },
-                "node-fetch": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-                    "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                }
-            }
         },
         "is-arguments": {
             "version": "1.1.1",
@@ -31315,11 +30097,6 @@
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "dev": true
-        },
-        "is-electron": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-            "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -31518,11 +30295,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
-        "iso-url": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
-            "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
-        },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -31603,63 +30375,6 @@
             "requires": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
-            }
-        },
-        "it-all": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-            "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg=="
-        },
-        "it-first": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
-            "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA=="
-        },
-        "it-glob": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
-            "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
-            "requires": {
-                "@types/minimatch": "^3.0.4",
-                "minimatch": "^3.0.4"
-            }
-        },
-        "it-last": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.0.tgz",
-            "integrity": "sha512-u0GHZ01tWYtPvDkOaqZSLLWjFv3IJw9cPL9mbEV7wnE8DOsbVoXIuKpnz3U6pySl5RzPVjTzSHOc961ZYttBxg=="
-        },
-        "it-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
-            "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA=="
-        },
-        "it-peekable": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.0.tgz",
-            "integrity": "sha512-+eacms2jr2wQqIRxU25eqWPHaEeR4IurrS9hTScmCJpWagRkC8WHw7atciEA6KArOiyxHCAXg5Q5We7/RhvqAQ=="
-        },
-        "it-pushable": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-            "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
-        },
-        "it-stream-types": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
-            "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA=="
-        },
-        "it-to-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
-            "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
-            "requires": {
-                "buffer": "^6.0.3",
-                "fast-fifo": "^1.0.0",
-                "get-iterator": "^1.0.2",
-                "p-defer": "^3.0.0",
-                "p-fifo": "^1.0.0",
-                "readable-stream": "^3.6.0"
             }
         },
         "jake": {
@@ -33567,11 +32282,6 @@
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "dev": true
         },
-        "long": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-            "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -33747,21 +32457,6 @@
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
         },
-        "merge-options": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-            "requires": {
-                "is-plain-obj": "^2.1.0"
-            },
-            "dependencies": {
-                "is-plain-obj": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-                    "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-                }
-            }
-        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -33899,6 +32594,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -33940,21 +32636,11 @@
                 "thunky": "^1.0.2"
             }
         },
-        "multiformats": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
-            "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
-        },
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
-        },
-        "native-fetch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-            "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-            "requires": {}
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -34455,20 +33141,6 @@
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
             "dev": true
         },
-        "p-defer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-            "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-        },
-        "p-fifo": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-            "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-            "requires": {
-                "fast-fifo": "^1.0.0",
-                "p-defer": "^3.0.0"
-            }
-        },
         "p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -34538,11 +33210,6 @@
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "parse-duration": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.2.tgz",
-            "integrity": "sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg=="
         },
         "parse-json": {
             "version": "5.2.0",
@@ -35584,25 +34251,6 @@
                 }
             }
         },
-        "protobufjs": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-            "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-            "requires": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            }
-        },
         "proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -35931,14 +34579,6 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
-        "react-native-fetch-api": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
-            "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
-            "requires": {
-                "p-defer": "^3.0.0"
-            }
-        },
         "react-refresh": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -36199,14 +34839,6 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "receptacle": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-            "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-            "requires": {
-                "ms": "^2.1.1"
-            }
-        },
         "recursive-readdir": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -36436,11 +35068,6 @@
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
             "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
             "dev": true
-        },
-        "retimer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-            "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
         },
         "retry": {
             "version": "0.13.1",
@@ -37100,19 +35727,6 @@
                 "xtend": "^4.0.2"
             }
         },
-        "stream-to-it": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-            "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-            "requires": {
-                "get-iterator": "^1.0.2"
-            }
-        },
-        "streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-        },
         "string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -37735,14 +36349,6 @@
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true
         },
-        "timeout-abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
-            "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
-            "requires": {
-                "retimer": "^3.0.0"
-            }
-        },
         "timers-browserify": {
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -37962,22 +36568,6 @@
             "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true
         },
-        "uint8arraylist": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
-            "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
-            "requires": {
-                "uint8arrays": "^4.0.2"
-            }
-        },
-        "uint8arrays": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-            "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-            "requires": {
-                "multiformats": "^11.0.0"
-            }
-        },
         "unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -37988,14 +36578,6 @@
                 "has-bigints": "^1.0.2",
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
-            }
-        },
-        "undici": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-            "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-            "requires": {
-                "busboy": "^1.6.0"
             }
         },
         "unicode-canonical-property-names-ecmascript": {
@@ -38188,11 +36770,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
             "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
-        },
-        "varint": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
         },
         "vary": {
             "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,6 @@
         "d3-shape": "^3.1.0",
         "d3-time-format": "^4.1.0",
         "express": "^4.18.1",
-        "ipfs-http-client": "^60.0.0",
         "jsonschema": "^1.4.1",
         "moment": "^2.29.4",
         "qr.js": "0.0.0",

--- a/client/src/app/components/stardust/Nft.tsx
+++ b/client/src/app/components/stardust/Nft.tsx
@@ -8,7 +8,7 @@ import NetworkContext from "../../context/NetworkContext";
 import {
     isSupportedImageFormat, tryParseNftMetadata, noMetadataPlaceholder,
     nonStandardMetadataPlaceholder, unregisteredMetadataPlaceholder,
-    unsupportedImageFormatPlaceholder, getNftImageContent
+    unsupportedImageFormatPlaceholder, getNftImageContent, loadingImagePlaceholder
 } from "./NftMetadataUtils";
 import { NftProps } from "./NftProps";
 import TruncatedId from "./TruncatedId";
@@ -22,7 +22,7 @@ const Nft: React.FC<NftProps> = ({ network, nft }) => {
     const nftAddress = Bech32AddressHelper.buildAddress(bech32Hrp, address);
     const [isWhitelisted] = useTokenRegistryNftCheck(network, nft.issuerId, id);
     const [name, setName] = useState<string | null>();
-    const uri = useNftMetadataUri(standardMetadata?.uri);
+    const [uri, isNftUriLoading] = useNftMetadataUri(standardMetadata?.uri);
 
     useEffect(() => {
         if (standardMetadata) {
@@ -30,12 +30,18 @@ const Nft: React.FC<NftProps> = ({ network, nft }) => {
         }
     }, [standardMetadata]);
 
+    const unsupportedFormatOrLoading = isNftUriLoading ? (
+        loadingImagePlaceholder
+    ) : (
+        unsupportedImageFormatPlaceholder
+    );
+
     const standardMetadataImageContent = !isWhitelisted ? (
         unregisteredMetadataPlaceholder
     ) : (standardMetadata && uri && isSupportedImageFormat(standardMetadata.type) ? (
         getNftImageContent(standardMetadata.type, uri, "nft-card__image")
     ) : (
-        unsupportedImageFormatPlaceholder
+        unsupportedFormatOrLoading
     ));
 
     const nftImageContent = !nft.metadata ? (

--- a/client/src/app/components/stardust/NftMetadataSection.tsx
+++ b/client/src/app/components/stardust/NftMetadataSection.tsx
@@ -8,7 +8,8 @@ import DataToggle from "../DataToggle";
 import JsonViewer from "../JsonViewer";
 import {
     getNftImageContent,
-    isSupportedImageFormat, MESSAGE_NFT_SCHEMA_STANDARD, tryParseNftMetadata, unsupportedImageFormatPlaceholder
+    isSupportedImageFormat, MESSAGE_NFT_SCHEMA_STANDARD, tryParseNftMetadata,
+    unsupportedImageFormatPlaceholder, loadingImagePlaceholder
 } from "./NftMetadataUtils";
 import "./NftMetadataSection.scss";
 import TruncatedId from "./TruncatedId";
@@ -28,13 +29,19 @@ interface NftMetadataSectionProps {
 const NftMetadataSection: React.FC<NftMetadataSectionProps> = ({ network, nft }) => {
     const [standardMetadata, setStandardMetadata] = useState<INftImmutableMetadata | null>();
     const [isWhitelisted] = useTokenRegistryNftCheck(network, nft.issuerId, nft.nftId);
-    const uri = useNftMetadataUri(standardMetadata?.uri);
+    const [uri, isNftUriLoading] = useNftMetadataUri(standardMetadata?.uri);
 
     useEffect(() => {
         if (nft.metadata) {
             setStandardMetadata(tryParseNftMetadata(nft.metadata));
         }
     }, [nft.metadata]);
+
+    const unsupportedFormatOrLoading = isNftUriLoading ? (
+        loadingImagePlaceholder
+    ) : (
+        unsupportedImageFormatPlaceholder
+    );
 
     const whitelistedNft = (
         standardMetadata && isWhitelisted ? (
@@ -43,7 +50,7 @@ const NftMetadataSection: React.FC<NftMetadataSectionProps> = ({ network, nft })
                     {(uri && isSupportedImageFormat(standardMetadata?.type) ? (
                         getNftImageContent(standardMetadata.type, uri, "nft-metadata__image")
                     ) : (
-                        unsupportedImageFormatPlaceholder
+                        unsupportedFormatOrLoading
                     ))}
                     <div className="nft-metadata__info col w100">
                         <ul>

--- a/client/src/app/components/stardust/NftMetadataUtils.tsx
+++ b/client/src/app/components/stardust/NftMetadataUtils.tsx
@@ -13,6 +13,7 @@ export const noMetadataPlaceholder = <ImagePlaceholder message="No metadata" com
 export const nonStandardMetadataPlaceholder = <ImagePlaceholder message="Unsupported metadata format" compact />;
 export const unsupportedImageFormatPlaceholder = <ImagePlaceholder message="Unsupported image format" />;
 export const unregisteredMetadataPlaceholder = <ImagePlaceholder message="Unregistered NFT metadata" compact />;
+export const loadingImagePlaceholder = <ImagePlaceholder message="Loading image..." isLoading />;
 
 /**
  * Tries to parse hex data into NFT immutable metadata (tip-27).

--- a/client/src/app/components/stardust/address/ImagePlaceholder.scss
+++ b/client/src/app/components/stardust/address/ImagePlaceholder.scss
@@ -23,6 +23,8 @@
     }
 
     &__content {
+        display: flex;
+
         @include font-size(28px);
         letter-spacing: 0.16em;
         font-family: $metropolis-light;

--- a/client/src/app/components/stardust/address/ImagePlaceholder.tsx
+++ b/client/src/app/components/stardust/address/ImagePlaceholder.tsx
@@ -1,26 +1,32 @@
 import classNames from "classnames";
 import React from "react";
+import Spinner from "../../Spinner";
 import "./ImagePlaceholder.scss";
 
 interface ImagePlaceholderProps {
     message: string;
     color?: string;
     compact?: boolean;
+    isLoading?: boolean;
 }
 
-export const ImagePlaceholder: React.FC<ImagePlaceholderProps> = ({ message, color, compact }) => (
+export const ImagePlaceholder: React.FC<ImagePlaceholderProps> = ({ message, color, compact, isLoading }) => (
     <div
         className={classNames("nft-image-placeholder", { compact })}
         style={{ backgroundColor: color ?? "#00e0ca" }}
     >
         <div className="nft-image-placeholder__content">
             {message}
+            {isLoading && (
+                <Spinner />
+            )}
         </div>
     </div>
 );
 
 ImagePlaceholder.defaultProps = {
     color: undefined,
-    compact: false
+    compact: false,
+    isLoading: false
 };
 

--- a/client/src/helpers/fetchHelper.ts
+++ b/client/src/helpers/fetchHelper.ts
@@ -80,7 +80,6 @@ export class FetchHelper {
         timeout?: number
     ): Promise<Response> {
         headers = headers ?? {};
-        headers["Content-Type"] = "application/json";
 
         let controller: AbortController | undefined;
         let timerId: NodeJS.Timeout | undefined;

--- a/client/src/helpers/hooks/useNftMetadataUri.ts
+++ b/client/src/helpers/hooks/useNftMetadataUri.ts
@@ -1,21 +1,34 @@
 import { useEffect, useState } from "react";
 import { getIPFSHash, getIpfsUri } from "../stardust/ipfsHelper";
 
-export const useNftMetadataUri = (link?: string) => {
+/**
+ * Get the correct nft metadata image uri
+ * @param link The image link
+ * @returns The uri and loading bool.
+ */
+export function useNftMetadataUri(link?: string):
+    [
+        string | undefined,
+        boolean
+    ] {
     const [uri, setUri] = useState<string | undefined>();
+    const [isLoading, setIsLoading] = useState<boolean>(true);
 
     useEffect(() => {
+        setIsLoading(true);
         const ipfsHash = getIPFSHash(link);
         if (ipfsHash) {
             // eslint-disable-next-line no-void
             void (async () => {
                 const ipfsUri = await getIpfsUri({ hash: ipfsHash });
                 setUri(ipfsUri);
+                setIsLoading(false);
             })();
         } else {
             setUri(link);
+            setIsLoading(false);
         }
     }, [link]);
 
-    return uri;
-};
+    return [uri, isLoading];
+}

--- a/client/src/helpers/stardust/ipfsHelper.ts
+++ b/client/src/helpers/stardust/ipfsHelper.ts
@@ -1,4 +1,3 @@
-import { ServiceFactory } from "../../factories/serviceFactory";
 import { IpfsClient } from "../../services/stardust/ipfsClient";
 /**
  * The ipfs endpoint.
@@ -30,11 +29,10 @@ export function getIPFSHash(url?: string): string | undefined {
  * @returns Path to a file.
  */
 export async function getIpfsUri(link: IpfsLink): Promise<string> {
-    const ipfsClient = ServiceFactory.get<IpfsClient>("ipfs-registry");
     let ipfsLink = `${IPFS_PATH}${link.hash}${link.path ?? ""}`;
 
     try {
-        const ipfsEntry = await ipfsClient.ls(ipfsLink);
+        const ipfsEntry = await IpfsClient.ls(ipfsLink);
 
         if (ipfsEntry) {
             if (ipfsEntry.type === "dir") {
@@ -47,3 +45,4 @@ export async function getIpfsUri(link: IpfsLink): Promise<string> {
 
     return `${IPFS_ENDPOINT}${ipfsLink}`;
 }
+

--- a/client/src/helpers/stardust/ipfsHelper.ts
+++ b/client/src/helpers/stardust/ipfsHelper.ts
@@ -1,6 +1,5 @@
-// eslint-disable-next-line import/no-unresolved
-import { create } from "ipfs-http-client";
-
+import { ServiceFactory } from "../../factories/serviceFactory";
+import { IpfsClient } from "../../services/stardust/ipfsClient";
 /**
  * The ipfs endpoint.
  */
@@ -31,20 +30,18 @@ export function getIPFSHash(url?: string): string | undefined {
  * @returns Path to a file.
  */
 export async function getIpfsUri(link: IpfsLink): Promise<string> {
-    const ipfsClient = create({ url: IPFS_ENDPOINT });
+    const ipfsClient = ServiceFactory.get<IpfsClient>("ipfs-registry");
     let ipfsLink = `${IPFS_PATH}${link.hash}${link.path ?? ""}`;
 
     try {
-        const ipfsContent = ipfsClient.ls(ipfsLink);
-        const iterator = ipfsContent[Symbol.asyncIterator]();
-        const ipfsEntry = await iterator.next();
+        const ipfsEntry = await ipfsClient.ls(ipfsLink);
 
-        if (!ipfsEntry.done) {
-            if (ipfsEntry.value.type === "dir") {
-                const path = `${link.path ?? ""}/${ipfsEntry.value.name}`;
+        if (ipfsEntry) {
+            if (ipfsEntry.type === "dir") {
+                const path = `${link.path ?? ""}/${ipfsEntry.name}`;
                 return await getIpfsUri({ hash: link.hash, path });
             }
-            ipfsLink = `${ipfsLink}/${encodeURIComponent(ipfsEntry.value.name)}`;
+            ipfsLink = `${ipfsLink}/${encodeURIComponent(ipfsEntry.name)}`;
         }
     } catch { }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -18,7 +18,6 @@ import { MilestonesClient } from "./services/milestonesClient";
 import { NetworkService } from "./services/networkService";
 import { NodeInfoService } from "./services/nodeInfoService";
 import { SettingsService } from "./services/settingsService";
-import { IpfsClient } from "./services/stardust/ipfsClient";
 import { StardustApiClient } from "./services/stardust/stardustApiClient";
 import { StardustFeedClient } from "./services/stardust/stardustFeedClient";
 import { StardustTangleCacheService } from "./services/stardust/stardustTangleCacheService";
@@ -57,8 +56,6 @@ async function initialiseServices(): Promise<void> {
     ServiceFactory.register("identity", () => new IdentityService());
 
     ServiceFactory.register("token-registry", () => new TokenRegistryClient());
-
-    ServiceFactory.register("ipfs-registry", () => new IpfsClient());
 
     const networkService = new NetworkService();
     await networkService.buildCache();

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -18,6 +18,7 @@ import { MilestonesClient } from "./services/milestonesClient";
 import { NetworkService } from "./services/networkService";
 import { NodeInfoService } from "./services/nodeInfoService";
 import { SettingsService } from "./services/settingsService";
+import { IpfsClient } from "./services/stardust/ipfsClient";
 import { StardustApiClient } from "./services/stardust/stardustApiClient";
 import { StardustFeedClient } from "./services/stardust/stardustFeedClient";
 import { StardustTangleCacheService } from "./services/stardust/stardustTangleCacheService";
@@ -56,6 +57,8 @@ async function initialiseServices(): Promise<void> {
     ServiceFactory.register("identity", () => new IdentityService());
 
     ServiceFactory.register("token-registry", () => new TokenRegistryClient());
+
+    ServiceFactory.register("ipfs-registry", () => new IpfsClient());
 
     const networkService = new NetworkService();
     await networkService.buildCache();

--- a/client/src/services/apiClient.ts
+++ b/client/src/services/apiClient.ts
@@ -72,9 +72,11 @@ export class ApiClient {
         timeout?: number
     ): Promise<IRawResponse> {
         let result: IRawResponse;
+        const headers = { "Content-Type": "application/json" };
+
         try {
             result = {
-                raw: await FetchHelper.raw(this._endpoint, path, method, request, undefined, timeout)
+                raw: await FetchHelper.raw(this._endpoint, path, method, request, headers, timeout)
             };
         } catch (err) {
             result = {

--- a/client/src/services/stardust/ipfsClient.ts
+++ b/client/src/services/stardust/ipfsClient.ts
@@ -33,7 +33,7 @@ interface IIPfsEntry {
     mode?: number;
     mtime?: Mtime;
     size: number;
-  }
+}
 /**
  * The ipfs endpoint.
  */
@@ -47,7 +47,7 @@ const IPFS_PREFIX = "/ipfs/";
  * Class to handle requests to ipfs.io.
  */
 export class IpfsClient {
-    public async ls(path: string): Promise<IIPfsEntry | undefined> {
+    public static async ls(path: string): Promise<IIPfsEntry | undefined> {
         let ipfsEntry;
         try {
             const response = await FetchHelper.raw(
@@ -61,26 +61,27 @@ export class IpfsClient {
             if (result) {
                 const links = result.Links;
                 if (links.length > 0) {
-                    ipfsEntry = this.mapLinkToIpfsEntry(links[0], path);
+                    ipfsEntry = IpfsClient.mapLinkToIpfsEntry(links[0], path);
                 }
             }
         } catch { }
+
         return ipfsEntry;
     }
 
-    public mapLinkToIpfsEntry(link: IIpfsLink, path: string): IIPfsEntry {
+    private static mapLinkToIpfsEntry(link: IIpfsLink, path: string): IIPfsEntry {
         const hash = link.Hash.startsWith(IPFS_PREFIX) ? link.Hash.slice(IPFS_PREFIX.length) : link.Hash;
 
         const entry: IIPfsEntry = {
-          name: link.Name,
-          path: path + (link.Name ? `/${link.Name}` : ""),
-          size: link.Size,
-          cid: hash,
-          type: this.typeOf(link)
+            name: link.Name,
+            path: path + (link.Name ? `/${link.Name}` : ""),
+            size: link.Size,
+            cid: hash,
+            type: IpfsClient.typeOf(link)
         };
 
         if (link.Mode) {
-           entry.mode = Number.parseInt(link.Mode, 8);
+            entry.mode = Number.parseInt(link.Mode, 8);
         }
 
         if (link.Mtime !== undefined && link.Mtime !== null) {
@@ -92,18 +93,19 @@ export class IpfsClient {
                 entry.mtime.nsecs = link.MtimeNsecs;
             }
         }
+
         return entry;
     }
 
-    public typeOf(link: IIpfsLink) {
+    private static typeOf(link: IIpfsLink) {
         switch (link.Type) {
-          case 1:
-          case 5:
-            return "dir";
-          case 2:
-            return "file";
-          default:
-            return "file";
+            case 1:
+            case 5:
+                return "dir";
+            case 2:
+                return "file";
+            default:
+                return "file";
         }
     }
 }

--- a/client/src/services/stardust/ipfsClient.ts
+++ b/client/src/services/stardust/ipfsClient.ts
@@ -1,0 +1,115 @@
+import { FetchHelper } from "../../helpers/fetchHelper";
+
+interface IIpfsLink {
+    Hash: string;
+    Name: string;
+    Size: number;
+    Target: string;
+    Type: number;
+    Mode?: string;
+    Mtime?: number;
+    MtimeNsecs?: number;
+}
+
+interface IIpfsObject {
+    Hash: string;
+    Links: IIpfsLink[];
+}
+
+interface ILSResponse {
+    Objects: IIpfsObject[];
+}
+
+interface Mtime {
+    secs: number;
+    nsecs?: number;
+}
+
+interface IIPfsEntry {
+    readonly type: "dir" | "file";
+    readonly cid: string;
+    readonly name: string;
+    readonly path: string;
+    mode?: number;
+    mtime?: Mtime;
+    size: number;
+  }
+/**
+ * The ipfs endpoint.
+ */
+const IPFS_ENDPOINT = "https://ipfs.io";
+
+const IPFS_PATH = "/api/v0/ls";
+
+const IPFS_PREFIX = "/ipfs/";
+
+/**
+ * Class to handle requests to ipfs.io.
+ */
+export class IpfsClient {
+    public async ls(path: string): Promise<IIPfsEntry | undefined> {
+        let response;
+        try {
+            response = await FetchHelper.raw(
+                IPFS_ENDPOINT,
+                `${IPFS_PATH}?arg=${path}`,
+                "get"
+            );
+            const lsResponse = await response.json() as ILSResponse;
+            if (!lsResponse.Objects) {
+                throw new Error("no Objects in results");
+            }
+            const result = lsResponse.Objects[0];
+
+            if (!result) {
+                throw new Error("expected one array in results.Objects");
+            }
+
+            const links = result.Links;
+            if (links.length > 0) {
+                return this.mapLinkToIpfsEntry(links[0], path);
+            }
+        } catch (e) {
+            console.log("Failed to fetch ipfs", e);
+        }
+    }
+
+    public mapLinkToIpfsEntry(link: IIpfsLink, path: string): IIPfsEntry {
+        const hash = link.Hash.startsWith(IPFS_PREFIX) ? link.Hash.slice(IPFS_PREFIX.length) : link.Hash;
+
+        const entry: IIPfsEntry = {
+          name: link.Name,
+          path: path + (link.Name ? `/${link.Name}` : ""),
+          size: link.Size,
+          cid: hash,
+          type: this.typeOf(link)
+        };
+
+        if (link.Mode) {
+           entry.mode = Number.parseInt(link.Mode, 8);
+        }
+
+        if (link.Mtime !== undefined && link.Mtime !== null) {
+            entry.mtime = {
+                secs: link.Mtime
+            };
+
+            if (link.MtimeNsecs !== undefined && link.MtimeNsecs !== null) {
+                entry.mtime.nsecs = link.MtimeNsecs;
+            }
+        }
+        return entry;
+    }
+
+    public typeOf(link: IIpfsLink) {
+        switch (link.Type) {
+          case 1:
+          case 5:
+            return "dir";
+          case 2:
+            return "file";
+          default:
+            return "file";
+        }
+    }
+}

--- a/client/src/services/stardust/ipfsClient.ts
+++ b/client/src/services/stardust/ipfsClient.ts
@@ -48,30 +48,24 @@ const IPFS_PREFIX = "/ipfs/";
  */
 export class IpfsClient {
     public async ls(path: string): Promise<IIPfsEntry | undefined> {
-        let response;
+        let ipfsEntry;
         try {
-            response = await FetchHelper.raw(
+            const response = await FetchHelper.raw(
                 IPFS_ENDPOINT,
                 `${IPFS_PATH}?arg=${path}`,
                 "get"
             );
             const lsResponse = await response.json() as ILSResponse;
-            if (!lsResponse.Objects) {
-                throw new Error("no Objects in results");
-            }
             const result = lsResponse.Objects[0];
 
-            if (!result) {
-                throw new Error("expected one array in results.Objects");
+            if (result) {
+                const links = result.Links;
+                if (links.length > 0) {
+                    ipfsEntry = this.mapLinkToIpfsEntry(links[0], path);
+                }
             }
-
-            const links = result.Links;
-            if (links.length > 0) {
-                return this.mapLinkToIpfsEntry(links[0], path);
-            }
-        } catch (e) {
-            console.log("Failed to fetch ipfs", e);
-        }
+        } catch { }
+        return ipfsEntry;
     }
 
     public mapLinkToIpfsEntry(link: IIpfsLink, path: string): IIPfsEntry {


### PR DESCRIPTION
# Description of change

- Removed http-ipfs-client lib dependency
- Added minimal ipfs client
- Added `isLoading` flag for fetching nft metadata uri and display loading image placholder when ipfs response is slow.

needed for #679 .

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
