### PR TITLE
Fix: Updated wording for block metadata

### DIFF
--- a/client/src/app/components/stardust/InclusionState.tsx
+++ b/client/src/app/components/stardust/InclusionState.tsx
@@ -12,14 +12,13 @@ const InclusionState: React.FC<InclusionStateProps> = ({ state }) => (
     <div className="inclusion-state">
         {state === undefined && ("The block is not yet referenced by a milestone.")}
         {state === "included" && (
-            "The block is referenced by a milestone, the transaction is included in the ledger."
+            "The block is confirmed by a milestone and the transaction successfully mutated the ledger state."
         )}
         {state === "noTransaction" && (
-            "The block is referenced by a milestone, the data is included in the ledger" +
-                ", but there is no value transfer."
+            "The block is referenced by a milestone but there is no value transfer."
         )}
         {state === "conflicting" && (
-            "The block has a conflict and will not be included in the ledger."
+            "The block is confirmed by a milestone but the transaction is conflicting."
         )}
     </div>
 );

--- a/client/src/app/components/stardust/block/section/BlockMetadataSection.tsx
+++ b/client/src/app/components/stardust/block/section/BlockMetadataSection.tsx
@@ -35,7 +35,7 @@ const BlockMetadataSection: React.FC<BlockMetadataSectionProps> = (
                     </div>
                     <div className="section--data">
                         <div className="label">
-                            Ledger Inclusion
+                            Inclusion Status
                         </div>
                         <div className="value row middle">
                             <InclusionState state={metadata?.ledgerInclusionState} />

--- a/client/src/app/routes/stardust/TransactionPage.tsx
+++ b/client/src/app/routes/stardust/TransactionPage.tsx
@@ -275,7 +275,7 @@ class TransactionPage extends AsyncComponent<RouteComponentProps<TransactionPage
                                     </div>
                                     <div className="section--data">
                                         <div className="label">
-                                            Ledger Inclusion
+                                            Inclusion Status
                                         </div>
                                         <div className="value row middle">
                                             <InclusionState


### PR DESCRIPTION
# Description of change

- Header changed to `Inclusion Status`.
- For transactionPayload blocks, if `ledgerInclusionState` is `confirmed` wording changed to "The block is confirmed by a milestone and the transaction successfully mutated the ledger state".
- For transactionPayload blocks, if `ledgerInclusionState` is `conflicting`  wording changed to "The block is confirmed by a milestone but the transaction is conflicting".
- And for `noTransaction` inclusion state wording changed to "The block is referenced by a milestone but there is no value transfer".

Resolves https://github.com/iotaledger/explorer/issues/686

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
