### PR TITLE
Feat: Improve searching outputs by Tag

### DIFF
--- a/api/src/models/api/stardust/ISearchResponse.ts
+++ b/api/src/models/api/stardust/ISearchResponse.ts
@@ -1,6 +1,7 @@
-import { IBlock, IOutputResponse, IOutputsResponse } from "@iota/iota.js-stardust";
+import { IBlock, IOutputResponse } from "@iota/iota.js-stardust";
 import { IResponse } from "../IResponse";
 import { IBech32AddressDetails } from "./IBech32AddressDetails";
+import { ITaggedOutputsResponse } from "./ITaggedOutputsResponse";
 import { IMilestoneDetailsResponse } from "./milestone/IMilestoneDetailsResponse";
 
 export interface ISearchResponse extends IResponse {
@@ -25,9 +26,9 @@ export interface ISearchResponse extends IResponse {
     output?: IOutputResponse;
 
     /**
-     * Output list.
+     * Basic and/or Nft tagged output ids.
      */
-    taggedOutputs?: IOutputsResponse;
+    taggedOutputs?: ITaggedOutputsResponse;
 
     /**
      * Alias id if it was found.

--- a/api/src/models/api/stardust/ITaggedOutputsRequest.ts
+++ b/api/src/models/api/stardust/ITaggedOutputsRequest.ts
@@ -1,0 +1,25 @@
+/**
+ * The request for Tagged Output Ids on stardust.
+ */
+export interface ITaggedOutputsRequest {
+    /**
+     * The network in context.
+     */
+    network: string;
+
+    /**
+     * The tag query.
+     */
+    tag: string;
+
+    /**
+     * The output type to be searched.
+     */
+    outputType: "basic" | "nft";
+
+    /**
+     * The cursor state for pagination.
+     */
+    cursor?: string;
+}
+

--- a/api/src/models/api/stardust/ITaggedOutputsResponse.ts
+++ b/api/src/models/api/stardust/ITaggedOutputsResponse.ts
@@ -1,0 +1,14 @@
+import { IBasicOutputsResponse } from "./basic/IBasicOutputsResponse";
+import { INftOutputsResponse } from "./nft/INftOutputsResponse";
+
+export interface ITaggedOutputsResponse {
+    /**
+     * The basic outputs data.
+     */
+    basicOutputs?: IBasicOutputsResponse;
+    /**
+     * The nft outputs data.
+     */
+    nftOutputs?: INftOutputsResponse;
+}
+

--- a/api/src/models/api/stardust/basic/IBasicOutputsResponse.ts
+++ b/api/src/models/api/stardust/basic/IBasicOutputsResponse.ts
@@ -1,0 +1,10 @@
+import { IOutputsResponse } from "@iota/iota.js-stardust";
+import { IResponse } from "../../IResponse";
+
+export interface IBasicOutputsResponse extends IResponse {
+    /**
+     * The output data.
+     */
+    outputs?: IOutputsResponse;
+}
+

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -103,6 +103,10 @@ export const routes: IRoute[] = [
         folder: "stardust/output/associated", func: "post", dataBody: true
     },
     {
+        path: "/stardust/output/tagged/:network/:tag/:outputType", method: "get",
+        folder: "stardust/output/tagged", func: "get"
+    },
+    {
         path: "/stardust/transactionhistory/:network/:address", method: "get",
         folder: "stardust/transactionhistory", func: "get"
     },

--- a/api/src/routes/stardust/output/tagged/get.ts
+++ b/api/src/routes/stardust/output/tagged/get.ts
@@ -1,0 +1,44 @@
+import { Converter } from "@iota/util.js-stardust";
+import { ServiceFactory } from "../../../../factories/serviceFactory";
+import { IBasicOutputsResponse } from "../../../../models/api/stardust/basic/IBasicOutputsResponse";
+import { ITaggedOutputsRequest } from "../../../../models/api/stardust/ITaggedOutputsRequest";
+import { INftOutputsResponse } from "../../../../models/api/stardust/nft/INftOutputsResponse";
+import { IConfiguration } from "../../../../models/configuration/IConfiguration";
+import { STARDUST } from "../../../../models/db/protocolVersion";
+import { NetworkService } from "../../../../services/networkService";
+import { StardustTangleHelper } from "../../../../utils/stardust/stardustTangleHelper";
+import { ValidationHelper } from "../../../../utils/validationHelper";
+
+/**
+ * Find the object from the network.
+ * @param _ The configuration.
+ * @param request The request.
+ * @returns The response.
+ */
+export async function get(
+    _: IConfiguration,
+    request: ITaggedOutputsRequest
+): Promise<IBasicOutputsResponse | INftOutputsResponse> {
+    const networkService = ServiceFactory.get<NetworkService>("network");
+    const networks = networkService.networkNames();
+    ValidationHelper.oneOf(request.network, networks, "network");
+    ValidationHelper.string(request.tag, "tag");
+    ValidationHelper.oneOf(request.outputType, ["basic", "nft"], "outputType");
+
+    const networkConfig = networkService.get(request.network);
+
+    if (networkConfig.protocolVersion !== STARDUST) {
+        return {};
+    }
+
+    const tagHex = Converter.utf8ToHex(request.tag, true);
+
+    if (request.outputType === "basic") {
+        return StardustTangleHelper.taggedBasicOutputs(networkConfig, tagHex, 10, request.cursor);
+    } else if (request.outputType === "nft") {
+        return StardustTangleHelper.taggedNftOutputs(networkConfig, tagHex, 10, request.cursor);
+    }
+
+    return { error: "Unsupported output type" };
+}
+

--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -226,30 +226,26 @@ export class SearchExecutor {
         if (searchQuery.tag) {
             promises.push(
                 new Promise((resolve, reject) => {
-                    StardustTangleHelper.tryFetchPermanodeThenNode<Record<string, unknown>, IOutputsResponse>(
-                        { tagHex: searchQuery.tag },
-                        "basicOutputs",
-                        network,
-                        true
-                    ).then(
-                        taggedOutputs => {
-                            if (taggedOutputs.items.length > 0) {
-                                promisesResult = {
-                                    taggedOutputs
-                                };
-                                resolve();
-                            } else {
-                                reject(new Error("Output (tagHex) not present"));
+                    StardustTangleHelper.taggedOutputs(network, searchQuery.tag)
+                        .then(
+                            response => {
+                                if (!response.basicOutputs.error || !response.nftOutputs.error) {
+                                    promisesResult = {
+                                        taggedOutputs: response
+                                    };
+                                    resolve();
+                                } else {
+                                    reject(new Error("Tagged outputs not present"));
+                                }
                             }
-                        }
-                    ).catch(_ => {
-                        reject(new Error("Output (tagHex) fetch failed"));
-                    });
+                        ).catch(_ => {
+                            reject(new Error("Tagged outputs not present"));
+                        });
                 })
             );
         }
 
-        await Promise.any(promises).catch(_ => {});
+        await Promise.any(promises).catch(_ => { });
 
         if (promisesResult !== null) {
             return promisesResult;

--- a/api/src/utils/stardust/searchQueryBuilder.ts
+++ b/api/src/utils/stardust/searchQueryBuilder.ts
@@ -1,4 +1,4 @@
-import { ALIAS_ADDRESS_TYPE, Bech32Helper, ED25519_ADDRESS_TYPE, NFT_ADDRESS_TYPE } from "@iota/iota.js-stardust";
+import { ALIAS_ADDRESS_TYPE, Bech32Helper, ED25519_ADDRESS_TYPE, HexEncodedString, NFT_ADDRESS_TYPE } from "@iota/iota.js-stardust";
 import { Converter, HexHelper } from "@iota/util.js-stardust";
 
 interface MaybeAddress {
@@ -73,7 +73,7 @@ export interface SearchQuery {
     /**
      * The tag of an output.
      */
-    tag?: string;
+    tag?: HexEncodedString;
 }
 
 /**
@@ -169,7 +169,7 @@ export class SearchQueryBuilder {
             address = undefined;
         }
 
-        const tag = Converter.utf8ToHex(this.query, true);
+        const tag: HexEncodedString = Converter.utf8ToHex(this.query, true);
 
         return {
             queryLower: this.queryLower,

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -4,7 +4,7 @@ import {
     IndexerPluginClient, blockIdFromMilestonePayload, milestoneIdFromMilestonePayload,
     IBlockMetadata, IMilestonePayload, IOutputsResponse, deserializeBlock, HexEncodedString
 } from "@iota/iota.js-stardust";
-import { Converter, HexHelper, ReadStream } from "@iota/util.js-stardust";
+import { HexHelper, ReadStream } from "@iota/util.js-stardust";
 import { ServiceFactory } from "../../factories/serviceFactory";
 import { IBasicOutputsResponse } from "../../models/api/stardust/basic/IBasicOutputsResponse";
 import { IFoundriesResponse } from "../../models/api/stardust/foundry/IFoundriesResponse";
@@ -468,43 +468,42 @@ export class StardustTangleHelper {
     /**
      * Get the basic output Ids with specific tag feature.
      * @param network The network to find the items on.
-     * @param tag The tag hex.
+     * @param encodedTag The tag hex.
      * @param pageSize The page size.
      * @param cursor The cursor for pagination.
      * @returns The basic outputs response.
      */
     public static async taggedBasicOutputs(
         network: INetwork,
-        tag: string,
+        encodedTag: HexEncodedString,
         pageSize: number,
         cursor?: string
     ): Promise<IBasicOutputsResponse | undefined> {
         try {
-            const tagHex: HexEncodedString = Converter.utf8ToHex(tag, true);
             const basicOutputIdsResponse: IOutputsResponse = await this.tryFetchPermanodeThenNode<
                 Record<string, unknown>,
                 IOutputsResponse
-            >({ tagHex, pageSize, cursor }, "basicOutputs", network, true);
+            >({ tagHex: encodedTag, pageSize, cursor }, "basicOutputs", network, true);
 
             if (basicOutputIdsResponse?.items.length > 0) {
                 return { outputs: basicOutputIdsResponse };
             }
         } catch { }
 
-        return { error: `Basic outputs not found with given tag ${tag}` };
+        return { error: `Basic outputs not found with given tag ${encodedTag}` };
     }
 
     /**
      * Get the nft output Ids with specific tag feature.
      * @param network The network to find the items on.
-     * @param tag The tag hex.
+     * @param encodedTag The tag hex.
      * @param pageSize The page size.
      * @param cursor The cursor for pagination.
      * @returns The nft outputs response.
      */
     public static async taggedNftOutputs(
         network: INetwork,
-        tag: HexEncodedString,
+        encodedTag: HexEncodedString,
         pageSize: number,
         cursor?: string
     ): Promise<INftOutputsResponse | undefined> {
@@ -512,14 +511,14 @@ export class StardustTangleHelper {
             const nftOutputIdsResponse: IOutputsResponse = await this.tryFetchPermanodeThenNode<
                 Record<string, unknown>,
                 IOutputsResponse
-            >({ tagHex: tag, pageSize, cursor }, "nfts", network, true);
+            >({ tagHex: encodedTag, pageSize, cursor }, "nfts", network, true);
 
             if (nftOutputIdsResponse?.items.length > 0) {
                 return { outputs: nftOutputIdsResponse };
             }
         } catch { }
 
-        return { error: `Nft outputs not found with given tag ${tag}` };
+        return { error: `Nft outputs not found with given tag ${encodedTag}` };
     }
 
     /**

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "explorer-client",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "explorer-client",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.6",

--- a/client/src/app/components/hoc/TabbedSection.tsx
+++ b/client/src/app/components/hoc/TabbedSection.tsx
@@ -75,7 +75,7 @@ const TabbedSection: React.FC<TabbedSectionProps> = ({ tabsEnum, children, tabOp
     const onTabSelected = (id: number) => {
         const tabParam = new URLSearchParams();
         tabParam.append("tab", Object.keys(tabsEnum)[id]);
-        history.push({ search: tabParam.toString() });
+        history.push({ ...location, search: tabParam.toString() });
     };
 
     const tabsView = (

--- a/client/src/app/components/stardust/Output.scss
+++ b/client/src/app/components/stardust/Output.scss
@@ -5,11 +5,16 @@
     padding: 0 30px;
     margin-bottom: 20px;
 
+    @include phone-down {
+        padding: 0 4px;
+    }
+
     .card--value.card-header--wrapper {
         width: 100%;
         display: flex;
         margin-bottom: 0px;
         height: 32px;
+        align-items: center;
 
         .output-header {
             display: flex;
@@ -43,8 +48,11 @@
         .amount-size {
             width: min-content;
             text-align: end;
+            word-break: normal;
+            white-space: nowrap;
             cursor: pointer;
-            margin-right: 2px;
+            margin-bottom: 0;
+            margin-right: 4px;
 
             span {
                 word-break: keep-all;
@@ -71,7 +79,7 @@
 }
 
 .card--content--dropdown {
-    margin-right: 4px;
+    margin-right: 8px;
     cursor: pointer;
 
     svg {

--- a/client/src/app/components/stardust/Unlocks.tsx
+++ b/client/src/app/components/stardust/Unlocks.tsx
@@ -31,7 +31,7 @@ const Unlocks: React.FC<IUnlocksProps> = ({ unlocks }) => {
                 onClick={() => setIsExpanded(!isExpanded)}
                 className="card--value card-header--wrapper"
             >
-                <div className={classNames("margin-r-t", "card--content--dropdown", { opened: isExpanded })}>
+                <div className={classNames("card--content--dropdown", { opened: isExpanded })}>
                     <DropdownIcon />
                 </div>
                 <div className="output-header">

--- a/client/src/app/components/stardust/block/payload/TransactionPayload.scss
+++ b/client/src/app/components/stardust/block/payload/TransactionPayload.scss
@@ -70,12 +70,6 @@
         color: var(--type-color);
       }
 
-      .amount-size {
-        text-align: end;
-        word-break: normal;
-        white-space: nowrap;
-      }
-
       .bech32-address {
         .value {
           @include font-size(14px);
@@ -96,21 +90,21 @@
           color: var(--body-color);
           padding: 10px;
           margin-bottom: 20px;
-  
+
           .unlocks-card--row {
               display: flex;
               flex-direction: row;
               align-items: center;
-  
+
               .public-key, .signature  {
                   padding-left: 10px;
                   max-width: 80%;
-  
+
                   @include phone-down {
                       max-width: 75%;
                   }
               }
-  
+
               .label {
                   @include font-size(12px);
                   color: var(--card-color);
@@ -119,7 +113,7 @@
                   letter-spacing: 0.5px;
                   white-space: nowrap;
               }
-  
+
               .value {
                   @include font-size(14px, 20px);
                   color: var(--body-color);
@@ -128,7 +122,7 @@
                   padding-left: 10px;
               }
           }
-        }  
+        }
       }
     }
   }

--- a/client/src/app/routes/stardust/OutputList.scss
+++ b/client/src/app/routes/stardust/OutputList.scss
@@ -41,6 +41,38 @@
                 justify-content: space-between;
             }
 
+            .output-list__basic, .output-list__nft {
+                .load-more--button {
+                    margin: 24px 0 8px 0;
+                    align-self: center;
+                    font-family: $metropolis;
+                    width: fit-content;
+                    padding: 4px 8px;
+                    cursor: pointer;
+
+                    &:hover {
+                        button {
+                            color: $main-green-highlight;
+                        }
+                    }
+
+                    button {
+                        padding: 6px;
+                        color: var(--header-icon-color);
+                    }
+                }
+
+                .outputs-over-limit {
+                    margin: 20px auto 0;
+                    align-items: center;
+                    background-color: var(--header-svg-bg);
+                    color: var(--body-color);
+                    font-family: $inter;
+                    font-size: 0.875rem;
+                    padding: 10px 24px;
+                }
+            }
+
             .section {
                 padding-top: 44px;
 

--- a/client/src/app/routes/stardust/OutputList.tsx
+++ b/client/src/app/routes/stardust/OutputList.tsx
@@ -1,120 +1,154 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable react/no-unescaped-entities */
-import { IOutputResponse } from "@iota/iota.js-stardust";
-import React, { useEffect, useState } from "react";
-import { RouteComponentProps, useLocation } from "react-router-dom";
-import { ServiceFactory } from "../../../factories/serviceFactory";
-import { STARDUST } from "../../../models/config/protocolVersion";
-import { StardustTangleCacheService } from "../../../services/stardust/stardustTangleCacheService";
+import React from "react";
+import { RouteComponentProps } from "react-router-dom";
+import { useTaggedOutputs } from "../../../helpers/hooks/useTaggedOutputs";
+import TabbedSection from "../../components/hoc/TabbedSection";
 import Pagination from "../../components/Pagination";
-import Spinner from "../../components/Spinner";
 import Output from "../../components/stardust/Output";
 import "./OutputList.scss";
 import OutputListProps from "./OutputListProps";
 
-interface OutputListLocationProps {
-    outputIds: string[];
-    tag: string;
-}
+const OUTPUTS_OVER_LIMIT_MESSAGE = "There are more than 100 outputs with this tag, only the first 100 are shown.";
 
-interface OutputListItem {
-    outputDetails: IOutputResponse;
-    outputId: string;
+export enum OUTPUT_LIST_TABS {
+    Basic = "Basic outputs",
+    Nft = "Nft outputs"
 }
-
-const TOKEN_PAGE_SIZE: number = 5;
 
 const OutputList: React.FC<RouteComponentProps<OutputListProps>> = (
     { match: { params: { network } } }
 ) => {
-    const [outputDetails, setOutputDetails] = useState<OutputListItem[]>([]);
-    const { outputIds, tag } = useLocation<OutputListLocationProps>().state ?? {
-        outputIds: [],
-        tag: ""
-    };
-    const [currentPage, setCurrentPage] = useState<OutputListItem[]>([]);
-    const [pageNumber, setPageNumber] = useState(1);
-    const [isLoading, setIsLoading] = useState(true);
+    const [
+        tag,
+        currentPageBasic,
+        currentPageNft,
+        totalBasicItems,
+        totalNftItems,
+        pageNumberBasic,
+        pageNumberNft,
+        setPageNumberBasic,
+        setPageNumberNft,
+        pageSize,
+        isBasicLoading,
+        isNftLoading,
+        basicOutputLimitReached,
+        nftOutputLimitReached,
+        hasMoreBasicOutputs,
+        hasMoreNftOutputs,
+        loadMoreCallback
+    ] = useTaggedOutputs(network);
 
-    useEffect(() => {
-        fetchOutputDetails();
-    }, []);
-
-    useEffect(() => {
-        const from = (pageNumber - 1) * TOKEN_PAGE_SIZE;
-        const to = from + TOKEN_PAGE_SIZE;
-        setCurrentPage(outputDetails.slice(from, to));
-    }, [outputDetails, pageNumber]);
-
-    const fetchOutputDetails = async () => {
-        if (outputIds.length > 0) {
-            // eslint-disable-next-line max-len
-            const stardustTangleCacheService = ServiceFactory.get<StardustTangleCacheService>(`tangle-cache-${STARDUST}`);
-            const outputs: OutputListItem[] = [];
-
-            for (const outputId of outputIds) {
-                const outputResponse = await stardustTangleCacheService.outputDetails(network, outputId);
-                if (!outputResponse.error && outputResponse.output && outputResponse.metadata) {
-                    const fetchedOutputDetails = {
-                        output: outputResponse.output,
-                        metadata: outputResponse.metadata
-                    };
-
-                    const item: OutputListItem = {
-                        outputDetails: fetchedOutputDetails,
-                        outputId
-                    };
-
-                    outputs.push(item);
-                }
-            }
-            setOutputDetails(outputs);
-        }
-        setIsLoading(false);
-    };
-
-    return outputDetails && outputDetails.length > 0 ?
+    return (
         <div className="output-list">
             <div className="wrapper">
                 <div className="inner">
                     <div className="output-list--header">
                         <div className="row middle">
-                            <h1>
-                                Outputs with tag "{tag}"
-                            </h1>
+                            <h1>{`Outputs with tag "${tag}"`}</h1>
                         </div>
                     </div>
-                    {currentPage.length > 0 &&
-                        <div className="section margin-b-s">
-                            {currentPage.map((item, index) => (
-                                <div key={index} className="card margin-b-s">
-                                    <Output
-                                        network={network}
-                                        outputId={item.outputId}
-                                        output={item.outputDetails.output}
-                                        amount={Number(item.outputDetails.output.amount)}
-                                        showCopyAmount={true}
-                                        isPreExpanded={false}
-                                    />
+                    <TabbedSection
+                        tabsEnum={OUTPUT_LIST_TABS}
+                        tabOptions={{
+                            [OUTPUT_LIST_TABS.Basic]: {
+                                disabled: isBasicLoading || totalBasicItems === 0,
+                                isLoading: isBasicLoading
+                            },
+                            [OUTPUT_LIST_TABS.Nft]: {
+                                disabled: isNftLoading || totalNftItems === 0,
+                                isLoading: isNftLoading
+                            }
+                        }}
+                    >
+                        <div className="output-list__basic">
+                            {currentPageBasic.length > 0 && (
+                                <div className="section margin-b-s">
+                                    {currentPageBasic.map((item, index) => (
+                                        <div key={index} className="card margin-b-t">
+                                            <Output
+                                                network={network}
+                                                outputId={item.outputId}
+                                                output={item.outputDetails.output}
+                                                amount={Number(item.outputDetails.output.amount)}
+                                                showCopyAmount={true}
+                                                isPreExpanded={false}
+                                            />
+                                        </div>
+                                    ))}
+                                    {totalBasicItems > pageSize && (
+                                        <Pagination
+                                            currentPage={pageNumberBasic}
+                                            totalCount={totalBasicItems}
+                                            pageSize={pageSize}
+                                            siblingsCount={1}
+                                            onPageChange={page => setPageNumberBasic(page)}
+                                        />
+                                    )}
+                                    {!basicOutputLimitReached ? (
+                                        <div className="card load-more--button">
+                                            <button
+                                                type="button"
+                                                onClick={async () => loadMoreCallback("basic")}
+                                                disabled={isBasicLoading}
+                                            >
+                                                Load more...
+                                            </button>
+                                        </div>
+                                    ) : hasMoreBasicOutputs && (
+                                        <div className="card outputs-over-limit">
+                                            {OUTPUTS_OVER_LIMIT_MESSAGE}
+                                        </div>
+                                    )}
                                 </div>
-                            ))}
-                        </div>}
-                    <Pagination
-                        currentPage={pageNumber}
-                        totalCount={outputDetails.length}
-                        pageSize={TOKEN_PAGE_SIZE}
-                        siblingsCount={1}
-                        onPageChange={number => setPageNumber(number)}
-                    />
+                            )}
+                        </div>
+                        <div className="output-list__nft">
+                            {currentPageNft.length > 0 && (
+                                <div className="section margin-b-s">
+                                    {currentPageNft.map((item, index) => (
+                                        <div key={index} className="card margin-b-t">
+                                            <Output
+                                                network={network}
+                                                outputId={item.outputId}
+                                                output={item.outputDetails.output}
+                                                amount={Number(item.outputDetails.output.amount)}
+                                                showCopyAmount={true}
+                                                isPreExpanded={false}
+                                            />
+                                        </div>
+                                    ))}
+                                    {totalNftItems > pageSize && (
+                                        <Pagination
+                                            currentPage={pageNumberNft}
+                                            totalCount={totalNftItems}
+                                            pageSize={pageSize}
+                                            siblingsCount={1}
+                                            onPageChange={page => setPageNumberNft(page)}
+                                        />
+                                    )}
+                                    {!nftOutputLimitReached ? (
+                                        <div className="card load-more--button">
+                                            <button
+                                                type="button"
+                                                onClick={async () => loadMoreCallback("nft")}
+                                                disabled={isNftLoading}
+                                            >
+                                                Load more...
+                                            </button>
+                                        </div>
+                                    ) : hasMoreNftOutputs && (
+                                        <div className="card outputs-over-limit">
+                                            {OUTPUTS_OVER_LIMIT_MESSAGE}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    </TabbedSection>
                 </div>
             </div>
-        </div> :
-        <div className="content row center card">
-            {isLoading ?
-                <Spinner /> :
-                <h2>No data available</h2>}
-        </div>;
+        </div>
+    );
 };
 
-
 export default OutputList;
+

--- a/client/src/app/routes/stardust/Search.tsx
+++ b/client/src/app/routes/stardust/Search.tsx
@@ -10,9 +10,9 @@ import { StardustTangleCacheService } from "../../../services/stardust/stardustT
 import AsyncComponent from "../../components/AsyncComponent";
 import Spinner from "../../components/Spinner";
 import NetworkContext from "../../context/NetworkContext";
-import "../Search.scss";
 import { SearchRouteProps } from "../SearchRouteProps";
 import { SearchState } from "../SearchState";
+import "../Search.scss";
 
 /**
  * Component which will show the search page.
@@ -245,7 +245,7 @@ class Search extends AsyncComponent<RouteComponentProps<SearchRouteProps>, Searc
                                 } else if (response.taggedOutputs) {
                                     route = "outputs";
                                     redirectState = {
-                                        outputIds: response.taggedOutputs.items,
+                                        outputIds: response.taggedOutputs,
                                         tag: query
                                     };
                                     routeParam = "";

--- a/client/src/helpers/hooks/useTaggedOutputs.ts
+++ b/client/src/helpers/hooks/useTaggedOutputs.ts
@@ -1,0 +1,204 @@
+import { IOutputResponse } from "@iota/iota.js-stardust";
+import { useEffect, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import { OUTPUT_LIST_TABS } from "../../app/routes/stardust/OutputList";
+import { ServiceFactory } from "../../factories/serviceFactory";
+import { ITaggedOutputsResponse } from "../../models/api/stardust/ITaggedOutputsResponse";
+import { STARDUST } from "../../models/config/protocolVersion";
+import { StardustTangleCacheService } from "../../services/stardust/stardustTangleCacheService";
+
+interface OutputListLocationProps {
+    outputIds: ITaggedOutputsResponse;
+    tag: string;
+}
+
+interface OutputListItem {
+    outputDetails: IOutputResponse;
+    outputId: string;
+}
+
+const PAGE_SIZE = 10;
+const OUTPUTS_LIMIT = 100;
+
+/**
+ * Fetch Tagged outputs with cursor.
+ * @param network The Network in context.
+ * @returns The taggedOutputs state.
+ */
+export function useTaggedOutputs(
+    network: string
+): [
+        string,
+        OutputListItem[],
+        OutputListItem[],
+        number,
+        number,
+        number,
+        number,
+        React.Dispatch<React.SetStateAction<number>>,
+        React.Dispatch<React.SetStateAction<number>>,
+        number,
+        boolean,
+        boolean,
+        boolean,
+        boolean,
+        boolean,
+        boolean,
+        (outputType: "basic" | "nft") => Promise<void>
+    ] {
+    const [tangleCacheService] = useState(
+        ServiceFactory.get<StardustTangleCacheService>(`tangle-cache-${STARDUST}`)
+    );
+    const location = useLocation<OutputListLocationProps>();
+    const searchParams = new URLSearchParams(location.search);
+    const history = useHistory();
+    const { outputIds, tag } = location.state ?? {
+        outputIds: [],
+        tag: ""
+    };
+
+    const [basicOutputItems, setBasicOutputItems] = useState<OutputListItem[] | null>(null);
+    const [nftOutputItems, setNftOutputItems] = useState<OutputListItem[] | null>(null);
+
+    const [basicOutputsCursor, setBasicOutputsCursor] = useState<string | undefined>();
+    const [nftOutputsCursor, setNftOutputsCursor] = useState<string | undefined>();
+
+    const [isBasicLoading, setIsBasicLoading] = useState(false);
+    const [isNftLoading, setIsNftLoading] = useState(false);
+
+    const [pageNumberBasic, setPageNumberBasic] = useState(1);
+    const [pageNumberNft, setPageNumberNft] = useState(1);
+
+    const [currentPageBasic, setCurrentPageBasic] = useState<OutputListItem[]>([]);
+    const [currentPageNft, setCurrentPageNft] = useState<OutputListItem[]>([]);
+
+    const loadOutputDetails = async (
+        outputs: string[],
+        setState: React.Dispatch<React.SetStateAction<OutputListItem[] | null>>,
+        setLoading: React.Dispatch<React.SetStateAction<boolean>>
+    ) => {
+        setLoading(true);
+        const itemsUpdate: OutputListItem[] = [];
+        const promises: Promise<void>[] = [];
+
+        for (const outputId of outputs) {
+            promises.push(
+                tangleCacheService.outputDetails(network, outputId)
+                    .then(outputDetailsResponse => {
+                        if (!outputDetailsResponse.error && outputDetailsResponse.output && outputDetailsResponse.metadata) {
+                            const item: OutputListItem = {
+                                outputDetails: {
+                                    output: outputDetailsResponse.output,
+                                    metadata: outputDetailsResponse.metadata
+                                },
+                                outputId
+                            };
+                            itemsUpdate.push(item);
+                        }
+                    })
+            );
+        }
+
+        try {
+            await Promise.all(promises);
+
+            setState(prevState => ([...(prevState ?? []), ...itemsUpdate]));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const loadMore = async (outputType: "basic" | "nft") => {
+        tangleCacheService.outputsByTag({
+            network, tag, outputType, cursor: outputType === "basic" ? basicOutputsCursor : nftOutputsCursor
+        }).then(response => {
+            if (!response.error && response.outputs) {
+                if (outputType === "basic") {
+                    // eslint-disable-next-line no-void
+                    void loadOutputDetails(response.outputs.items, setBasicOutputItems, setIsBasicLoading);
+                    setBasicOutputsCursor(response.outputs.cursor);
+                }
+
+                if (outputType === "nft") {
+                    // eslint-disable-next-line no-void
+                    void loadOutputDetails(response.outputs.items, setNftOutputItems, setIsNftLoading);
+                    setNftOutputsCursor(response.outputs.cursor);
+                }
+            }
+        }).catch(_ => { });
+    };
+
+    useEffect(() => {
+        setBasicOutputItems(null);
+        setNftOutputItems(null);
+        // basic output ids
+        if (outputIds.basicOutputs?.outputs?.items) {
+            // eslint-disable-next-line no-void
+            void loadOutputDetails(outputIds.basicOutputs.outputs.items, setBasicOutputItems, setIsBasicLoading);
+            setBasicOutputsCursor(outputIds.basicOutputs.outputs.cursor);
+        }
+        // nft output ids
+        if (outputIds.nftOutputs?.outputs?.items) {
+            // eslint-disable-next-line no-void
+            void loadOutputDetails(outputIds.nftOutputs.outputs.items, setNftOutputItems, setIsNftLoading);
+            setNftOutputsCursor(outputIds.nftOutputs.outputs.cursor);
+        }
+    }, [network]);
+
+    useEffect(() => {
+        if (!isNftLoading && !isNftLoading && !searchParams.get("tab")) {
+            const hasBasicOutputs = (basicOutputItems ?? []).length > 0;
+            const hasNftOutputs = (nftOutputItems ?? []).length > 0;
+            if (!hasBasicOutputs && hasNftOutputs) {
+                searchParams.append("tab", Object.keys(OUTPUT_LIST_TABS)[1]);
+            } else {
+                searchParams.append("tab", Object.keys(OUTPUT_LIST_TABS)[0]);
+            }
+
+            history.push({ ...location, search: searchParams.toString() });
+        }
+    }, [isBasicLoading, isNftLoading, basicOutputItems, nftOutputItems]);
+
+    useEffect(() => {
+        const from = (pageNumberBasic - 1) * PAGE_SIZE;
+        const to = from + PAGE_SIZE;
+        if (basicOutputItems) {
+            setCurrentPageBasic(basicOutputItems.slice(from, to));
+        }
+    }, [basicOutputItems, pageNumberBasic]);
+
+    useEffect(() => {
+        const from = (pageNumberNft - 1) * PAGE_SIZE;
+        const to = from + PAGE_SIZE;
+        if (nftOutputItems) {
+            setCurrentPageNft(nftOutputItems.slice(from, to));
+        }
+    }, [nftOutputItems, pageNumberNft]);
+
+    const totalBasicItems = (basicOutputItems ?? []).length;
+    const totalNftItems = (nftOutputItems ?? []).length;
+    const basicOutputLimitReached = totalBasicItems >= OUTPUTS_LIMIT;
+    const nftOutputLimitReached = totalNftItems >= OUTPUTS_LIMIT;
+    const hasMoreBasicOutputs = Boolean(basicOutputsCursor);
+    const hasMoreNftOutputs = Boolean(nftOutputsCursor);
+
+    return [
+        tag,
+        currentPageBasic,
+        currentPageNft,
+        totalBasicItems,
+        totalNftItems,
+        pageNumberBasic,
+        pageNumberNft,
+        setPageNumberBasic,
+        setPageNumberNft,
+        PAGE_SIZE,
+        isBasicLoading,
+        isNftLoading,
+        basicOutputLimitReached,
+        nftOutputLimitReached,
+        hasMoreBasicOutputs,
+        hasMoreNftOutputs,
+        loadMore
+    ];
+}

--- a/client/src/helpers/hooks/useTaggedOutputs.ts
+++ b/client/src/helpers/hooks/useTaggedOutputs.ts
@@ -146,7 +146,7 @@ export function useTaggedOutputs(
     }, [network]);
 
     useEffect(() => {
-        if (!isNftLoading && !isNftLoading && !searchParams.get("tab")) {
+        if (!isBasicLoading && !isNftLoading && !searchParams.get("tab")) {
             const hasBasicOutputs = (basicOutputItems ?? []).length > 0;
             const hasNftOutputs = (nftOutputItems ?? []).length > 0;
             if (!hasBasicOutputs && hasNftOutputs) {

--- a/client/src/models/api/stardust/ISearchResponse.ts
+++ b/client/src/models/api/stardust/ISearchResponse.ts
@@ -7,6 +7,7 @@ import { IAssociationsResponse } from "./IAssociationsResponse";
 import { IMilestoneBlocksResponse } from "./IMilestoneBlocksResponse";
 import { IMilestoneDetailsResponse } from "./IMilestoneDetailsResponse";
 import { IInfluxDailyResponse } from "./influx/IInfluxDailyResponse";
+import { ITaggedOutputsResponse } from "./ITaggedOutputsResponse";
 import { ITransactionHistoryResponse } from "./ITransactionHistoryResponse";
 
 export interface ISearchResponse extends IResponse {
@@ -36,9 +37,9 @@ export interface ISearchResponse extends IResponse {
     addressOutputs?: IOutputResponse[];
 
     /**
-     * Outputs response.
+     * Basic and/or Nft tagged output ids.
      */
-    taggedOutputs?: IOutputsResponse;
+    taggedOutputs?: ITaggedOutputsResponse;
 
     /**
      * The outputIds of transaction history request.

--- a/client/src/models/api/stardust/ITaggedOutputsRequest.ts
+++ b/client/src/models/api/stardust/ITaggedOutputsRequest.ts
@@ -1,0 +1,25 @@
+/**
+ * The request for Tagged Output Ids on stardust.
+ */
+export interface ITaggedOutputsRequest {
+    /**
+     * The network in context.
+     */
+    network: string;
+
+    /**
+     * The tag query.
+     */
+    tag: string;
+
+    /**
+     * The output type to be searched.
+     */
+    outputType: "basic" | "nft";
+
+    /**
+     * The cursor state for pagination.
+     */
+    cursor?: string;
+}
+

--- a/client/src/models/api/stardust/ITaggedOutputsResponse.ts
+++ b/client/src/models/api/stardust/ITaggedOutputsResponse.ts
@@ -1,0 +1,14 @@
+import { IBasicOutputsResponse } from "./basic/IBasicOutputsResponse";
+import { INftOutputsResponse } from "./nft/INftOutputsResponse";
+
+export interface ITaggedOutputsResponse {
+    /**
+     * The basic outputs data.
+     */
+    basicOutputs?: IBasicOutputsResponse;
+    /**
+     * The nft outputs data.
+     */
+    nftOutputs?: INftOutputsResponse;
+}
+

--- a/client/src/models/api/stardust/basic/IBasicOutputsResponse.ts
+++ b/client/src/models/api/stardust/basic/IBasicOutputsResponse.ts
@@ -1,0 +1,10 @@
+import { IOutputsResponse } from "@iota/iota.js-stardust";
+import { IResponse } from "../../IResponse";
+
+export interface IBasicOutputsResponse extends IResponse {
+    /**
+     * The output data.
+     */
+    outputs?: IOutputsResponse;
+}
+

--- a/client/src/services/stardust/stardustApiClient.ts
+++ b/client/src/services/stardust/stardustApiClient.ts
@@ -1,3 +1,4 @@
+import { IOutputsResponse } from "@iota/iota.js-stardust";
 import { FetchHelper } from "../../helpers/fetchHelper";
 import { IIdentityStardustResolveRequest } from "../../models/api/IIdentityStardustResolveRequest";
 import { IIdentityStardustResolveResponse } from "../../models/api/IIdentityStardustResolveResponse";
@@ -33,6 +34,7 @@ import { INodeInfoResponse } from "../../models/api/stardust/INodeInfoResponse";
 import { IOutputDetailsResponse } from "../../models/api/stardust/IOutputDetailsResponse";
 import { ISearchRequest } from "../../models/api/stardust/ISearchRequest";
 import { ISearchResponse } from "../../models/api/stardust/ISearchResponse";
+import { ITaggedOutputsRequest } from "../../models/api/stardust/ITaggedOutputsRequest";
 import { ITransactionDetailsRequest } from "../../models/api/stardust/ITransactionDetailsRequest";
 import { ITransactionDetailsResponse } from "../../models/api/stardust/ITransactionDetailsResponse";
 import { ITransactionHistoryRequest } from "../../models/api/stardust/ITransactionHistoryRequest";
@@ -189,6 +191,20 @@ export class StardustApiClient extends ApiClient {
     public async outputDetails(request: IOutputDetailsRequest): Promise<IOutputDetailsResponse> {
         return this.callApi<unknown, IOutputDetailsResponse>(
             `stardust/output/${request.network}/${request.outputId}`, "get"
+        );
+    }
+
+    /**
+     * Get the output ids by tag feature (basic or nft).
+     * @param request The request to send.
+     * @returns The response from the request.
+     */
+    public async outputsByTag(request: ITaggedOutputsRequest): Promise<{ error?: string; outputs?: IOutputsResponse }> {
+        const params = FetchHelper.urlParams({ cursor: request.cursor });
+
+        return this.callApi<unknown, { error?: string; outputs?: IOutputsResponse }>(
+            `stardust/output/tagged/${request.network}/${request.tag}/${request.outputType}${params}`,
+            "get"
         );
     }
 

--- a/client/src/services/stardust/stardustTangleCacheService.ts
+++ b/client/src/services/stardust/stardustTangleCacheService.ts
@@ -17,6 +17,7 @@ import { IAssociationsResponse } from "../../models/api/stardust/IAssociationsRe
 import { IMilestoneBlocksResponse } from "../../models/api/stardust/IMilestoneBlocksResponse";
 import { IInfluxDailyResponse } from "../../models/api/stardust/influx/IInfluxDailyResponse";
 import { ISearchResponse } from "../../models/api/stardust/ISearchResponse";
+import { ITaggedOutputsRequest } from "../../models/api/stardust/ITaggedOutputsRequest";
 import { ITransactionHistoryRequest } from "../../models/api/stardust/ITransactionHistoryRequest";
 import { ITransactionHistoryResponse } from "../../models/api/stardust/ITransactionHistoryResponse";
 import { INftDetailsRequest } from "../../models/api/stardust/nft/INftDetailsRequest";
@@ -656,6 +657,19 @@ export class StardustTangleCacheService extends TangleCacheService {
             nftDetails: this._stardustSearchCache[request.network][cacheKey]
                 ?.data?.nftDetails
         };
+    }
+
+    /**
+     * Get the output ids by tag feature (basic or nft).
+     * @param request The request to send.
+     * @returns The response from the request.
+     */
+    public async outputsByTag(request: ITaggedOutputsRequest): Promise<{ error?: string; outputs?: IOutputsResponse }> {
+        const response = await this._api.outputsByTag(request);
+
+        return !response.error ?
+            { outputs: response.outputs } :
+            { error: response.error };
     }
 
     /**


### PR DESCRIPTION
# Description of change

- Search by tag now also searches Nft outputs
- OutputList page reworked with pagination and TabbedSections (basic/nft)
- OutputList results are backend paginated up to a limit of 100 outputs

⚠️ This needs a chronicle with this https://github.com/iotaledger/inx-chronicle/pull/1171 deployed, otherwise permanode won't return the outputs properly

Resolves https://github.com/iotaledger/explorer/issues/692

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
