### PR TITLE
Fix: Data Toggle for Participation events  

### DIFF
--- a/client/src/app/components/stardust/Feature.tsx
+++ b/client/src/app/components/stardust/Feature.tsx
@@ -11,7 +11,6 @@ const Feature: React.FC<FeatureProps> = (
     { feature, isImmutable, isPreExpanded, isParticipationEventMetadata }
 ) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(isPreExpanded ?? false);
-
     return (
         <div className="feature-block">
             <div
@@ -44,7 +43,7 @@ const Feature: React.FC<FeatureProps> = (
                             <DataToggle
                                 sourceData={feature.data}
                                 withSpacedHex={true}
-                                isParticipationEventMetadata
+                                isParticipationEventMetadata={isParticipationEventMetadata}
                             />
                         </div>
                     )}


### PR DESCRIPTION
# Description of change

Use the `isParticipationMetadataFlag` in Feature that to display Data toggle correctly
 fixes #733 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
