### PR TITLE
Feat: Display blocks with reattached transaction on Visualizer 

### DIFF
--- a/client/src/app/components/header/Header.tsx
+++ b/client/src/app/components/header/Header.tsx
@@ -328,6 +328,8 @@ class Header extends Component<HeaderProps, HeaderState> {
             darkMode: !this.state.darkMode
         }, () => {
             this._settingsService.saveSingle("darkMode", this.state.darkMode);
+            const event = new CustomEvent("theme-change", { detail: { darkMode: this.state.darkMode } });
+            window.dispatchEvent(event);
         });
         this.toggleModeClass();
     }

--- a/client/src/app/routes/stardust/Visualizer.scss
+++ b/client/src/app/routes/stardust/Visualizer.scss
@@ -134,6 +134,7 @@
     }
 
     @include phone-down {
+      left: 10px;
       .stats-panel {
         .card--value,
         .card--label {
@@ -157,12 +158,16 @@
       width: 320px;
       overflow: visible;
 
-      @include phone-down {
-          top: 10px;
-          left: 10px;
-          width: 90%;
+      @include tablet-down {
+          top: 140px;
+          width: 46%;
       }
 
+      @include phone-down {
+          top: 200px;
+          left: 10px;
+          width: 60%;
+      }
 
       button {
           position: absolute;

--- a/client/src/app/routes/stardust/Visualizer.scss
+++ b/client/src/app/routes/stardust/Visualizer.scss
@@ -155,12 +155,14 @@
       top: 100px;
       left: 20px;
       width: 320px;
+      overflow: visible;
 
       @include phone-down {
           top: 10px;
           left: 10px;
           width: 90%;
       }
+
 
       button {
           position: absolute;
@@ -172,6 +174,12 @@
           padding: 20px 30px;
       }
 
+      .tooltip {
+
+        .wrap {
+          width: 250px;
+        }
+      }
   }
 
   .key-panel-container {

--- a/client/src/app/routes/stardust/Visualizer.scss
+++ b/client/src/app/routes/stardust/Visualizer.scss
@@ -177,7 +177,7 @@
       .tooltip {
 
         .wrap {
-          width: 250px;
+          width: 180px;
         }
       }
   }

--- a/client/src/app/routes/stardust/Visualizer.scss
+++ b/client/src/app/routes/stardust/Visualizer.scss
@@ -237,7 +237,7 @@
                   }
 
                   &.vertex-state--search-result {
-                      background-color: #e79c18;
+                      background-color: #C061E8;
                   }
               }
 

--- a/client/src/app/routes/stardust/Visualizer.tsx
+++ b/client/src/app/routes/stardust/Visualizer.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import { CONFLICT_REASON_STRINGS } from "@iota/iota.js-stardust";
+import { CONFLICT_REASON_STRINGS, ConflictReason } from "@iota/iota.js-stardust";
 import { Converter } from "@iota/util.js-stardust";
 import React, { useContext, useRef } from "react";
-import { RouteComponentProps } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { ReactComponent as CloseIcon } from "../../../assets/close.svg";
+import { DateHelper } from "../../../helpers/dateHelper";
 import { useNetworkConfig } from "../../../helpers/hooks/useNetworkConfig";
 import { useNetworkStats } from "../../../helpers/hooks/useNetworkStats";
 import { useVisualizerState } from "../../../helpers/hooks/useVisualizerState";
-import { RouteBuilder } from "../../../helpers/routeBuilder";
 import { formatAmount } from "../../../helpers/stardust/valueFormatHelper";
 import Modal from "../../components/Modal";
 import BlockTangleState from "../../components/stardust/block/BlockTangleState";
+import TruncatedId from "../../components/stardust/TruncatedId";
 import NetworkContext from "../../context/NetworkContext";
 import { VisualizerRouteProps } from "../VisualizerRouteProps";
 import mainHeader from "./../../../assets/modals/visualizer/main-header.json";
@@ -37,12 +38,13 @@ export const Visualizer: React.FC<RouteComponentProps<VisualizerRouteProps>> = (
         lastClick
     ] = useVisualizerState(network, graphElement);
 
-    const status = selectedFeedItem?.metadata?.referenced ?
-            "referenced" :
-            undefined;
-    const conflictReason = selectedFeedItem?.metadata?.conflictReason ?
-        CONFLICT_REASON_STRINGS[selectedFeedItem.metadata.conflictReason] :
-        undefined;
+    const getStatus = (referenced?: number) => (referenced ? "referenced" : undefined);
+    const getConflictReasonMessage = (conflictReason?: ConflictReason) => (
+        conflictReason ?
+            CONFLICT_REASON_STRINGS[conflictReason] :
+            undefined
+    );
+    const properties = selectedFeedItem?.properties;
 
     return (
         <div className="visualizer-stardust">
@@ -124,87 +126,96 @@ export const Visualizer: React.FC<RouteComponentProps<VisualizerRouteProps>> = (
                                         <span className="margin-l-t">
                                             <BlockTangleState
                                                 network={network}
-                                                status={status}
+                                                status={getStatus(selectedFeedItem?.metadata?.referenced)}
                                                 hasConflicts={selectedFeedItem.metadata?.conflicting}
-                                                conflictReason={conflictReason}
+                                                conflictReason={getConflictReasonMessage(
+                                                    selectedFeedItem?.metadata?.conflictReason
+                                                )}
                                             />
                                         </span>
                                     )}
                                 </div>
                                 <div className="card--value overflow-ellipsis">
-                                    <a
-                                        className="button"
+                                    <Link
+                                        to={`/${networkConfig.network
+                                            }/block/${selectedFeedItem?.blockId}`}
                                         target="_blank"
-                                        rel="noopener noreferrer"
-                                        href={
-                                            `${window.location.origin}${RouteBuilder
-                                                .buildItem(networkConfig, selectedFeedItem.blockId)}`
-                                        }
                                     >
-                                        {selectedFeedItem.blockId}
-                                    </a>
+                                        <TruncatedId id={selectedFeedItem.blockId} />
+                                    </Link>
                                 </div>
                                 {selectedFeedItem?.transactionId && (
                                     <React.Fragment>
                                         <div className="card--label">Transaction id</div>
-                                        <div className="card--value overflow-ellipsis">
-                                            <a
-                                                className="button"
+                                        <div className="card--value">
+                                            <Link
+                                                to={`/${networkConfig.network
+                                                    }/transaction/${selectedFeedItem?.transactionId}`}
                                                 target="_blank"
-                                                rel="noopener noreferrer"
-                                                href={
-                                                    `/${networkConfig.network
-                                                    }/transaction/${selectedFeedItem?.transactionId}`
-                                                }
                                             >
-                                                {selectedFeedItem?.transactionId}
-                                            </a>
+                                                <TruncatedId id={selectedFeedItem?.transactionId} />
+                                            </Link>
                                         </div>
                                     </React.Fragment>
                                 )}
-                                {selectedFeedItem?.properties?.Tag &&
-                                    selectedFeedItem.metadata?.milestone === undefined && (
-                                        <React.Fragment>
-                                            <div className="card--label">Tag</div>
-                                            <div className="card--value overflow-ellipsis">
-                                                <a
-                                                    className="button"
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                >
-                                                    {selectedFeedItem?.properties.Tag as string}
-                                                </a>
-                                            </div>
-                                        </React.Fragment>
-                                    )}
-                                {selectedFeedItem?.properties?.Index && (
+                                {properties?.tag && (
                                     <React.Fragment>
                                         <div className="card--label">Tag</div>
-                                        <div className="card--value overflow-ellipsis">
-                                            <a className="button" target="_blank" rel="noopener noreferrer">
-                                                {Converter.hexToUtf8(
-                                                    selectedFeedItem?.properties.Index as string
-                                                )}
-                                            </a>
+                                        <div className="card--value truncate">
+                                            {Converter.hexToUtf8(
+                                                properties.tag
+                                            )}
                                         </div>
-                                        <div className="card--label">
-                                            Index Hex
-                                        </div>
-                                        <div className="card--value overflow-ellipsis">
-                                            <a className="button" target="_blank" rel="noopener noreferrer">
-                                                {selectedFeedItem?.properties.Index as string}
-                                            </a>
+                                        <div className="card--label">Hex</div>
+                                        <div className="card--value truncate">
+                                            {properties.tag}
                                         </div>
                                     </React.Fragment>
                                 )}
                                 {selectedFeedItem.metadata?.milestone !== undefined && (
                                     <React.Fragment>
+                                        {properties?.milestoneId && (
+                                            <React.Fragment>
+                                                <div className="card--label">
+                                                    Milestone id
+                                                </div>
+                                                <div className="card--value">
+                                                    <Link
+                                                        to={`/${networkConfig.network
+                                                            }/block/${selectedFeedItem?.blockId}`}
+                                                        target="_blank"
+                                                    >
+                                                        <TruncatedId id={properties.milestoneId} />
+                                                    </Link>
+                                                </div>
+                                            </React.Fragment>
+                                        )}
                                         <div className="card--label">
-                                            Milestone
+                                            Milestone index
                                         </div>
                                         <div className="card--value">
-                                            {selectedFeedItem.metadata.milestone}
+                                            <Link
+                                                to={`/${networkConfig.network
+                                                    }/block/${selectedFeedItem?.blockId}`}
+                                                target="_blank"
+                                            >
+                                                {selectedFeedItem.metadata.milestone}
+                                            </Link>
                                         </div>
+                                        {properties?.timestamp && (
+                                            <React.Fragment>
+                                                <div className="card--label">
+                                                    Timestamp
+                                                </div>
+                                                <div className="card--value">
+                                                    {DateHelper.formatShort(
+                                                        DateHelper.milliseconds(
+                                                            properties.timestamp
+                                                        )
+                                                    )}
+                                                </div>
+                                            </React.Fragment>
+                                        )}
                                     </React.Fragment>
                                 )}
                                 {selectedFeedItem?.value !== undefined &&
@@ -233,28 +244,23 @@ export const Visualizer: React.FC<RouteComponentProps<VisualizerRouteProps>> = (
                                         <div className="card--label">Reattachments</div>
                                         {selectedFeedItem.reattachments.map((item, index) => (
                                             <div key={index} className="card--value row">
-                                                <a
-                                                    className="button truncate"
+                                                <Link
+                                                    to={`/${networkConfig.network
+                                                        }/block/${item.blockId}`}
+                                                    className="truncate"
                                                     target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    href={
-                                                        `${window.location.origin}${RouteBuilder
-                                                            .buildItem(networkConfig, item.blockId)}`
-                                                    }
                                                 >
-                                                    {item?.blockId}
-                                                </a>
+                                                    <TruncatedId id={item.blockId} />
+                                                </Link>
                                                 {item?.metadata && (
                                                     <span className="margin-l-t">
                                                         <BlockTangleState
                                                             network={network}
-                                                            status={item.metadata?.referenced ?
-                                                                "referenced" :
-                                                                undefined}
+                                                            status={getStatus(item.metadata?.referenced)}
                                                             hasConflicts={item.metadata?.conflicting}
-                                                            conflictReason={item.metadata?.conflictReason ?
-                                                                CONFLICT_REASON_STRINGS[item.metadata?.conflictReason] :
-                                                                undefined}
+                                                            conflictReason={getConflictReasonMessage(
+                                                                item.metadata?.conflictReason
+                                                            )}
                                                         />
                                                     </span>
                                                 )}

--- a/client/src/app/routes/stardust/Visualizer.tsx
+++ b/client/src/app/routes/stardust/Visualizer.tsx
@@ -144,16 +144,16 @@ export const Visualizer: React.FC<RouteComponentProps<VisualizerRouteProps>> = (
                                         <TruncatedId id={selectedFeedItem.blockId} />
                                     </Link>
                                 </div>
-                                {selectedFeedItem?.transactionId && (
+                                {properties?.transactionId && (
                                     <React.Fragment>
                                         <div className="card--label">Transaction id</div>
                                         <div className="card--value">
                                             <Link
                                                 to={`/${networkConfig.network
-                                                    }/transaction/${selectedFeedItem?.transactionId}`}
+                                                    }/transaction/${properties?.transactionId}`}
                                                 target="_blank"
                                             >
-                                                <TruncatedId id={selectedFeedItem?.transactionId} />
+                                                <TruncatedId id={properties?.transactionId} />
                                             </Link>
                                         </div>
                                     </React.Fragment>

--- a/client/src/helpers/hooks/useVisualizerState.tsx
+++ b/client/src/helpers/hooks/useVisualizerState.tsx
@@ -1,4 +1,4 @@
-import { Converter, HexHelper } from "@iota/util.js-stardust";
+import { Converter } from "@iota/util.js-stardust";
 import { useEffect, useRef, useState } from "react";
 import Viva from "vivagraphjs";
 import { ServiceFactory } from "../../factories/serviceFactory";
@@ -80,7 +80,7 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
                 if (graph.current) {
                     const now = Date.now();
 
-                    const blockId = HexHelper.stripPrefix(newBlock.blockId);
+                    const blockId = newBlock.blockId;
                     const existingNode = graph.current.getNode(blockId);
 
                     if (!existingNode) {
@@ -94,7 +94,7 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
                         if (newBlock.parents) {
                             const addedParents: string[] = [];
                             for (let i = 0; i < newBlock.parents.length; i++) {
-                                const parentId = HexHelper.stripPrefix(newBlock.parents[i]);
+                                const parentId = newBlock.parents[i];
                                 if (!addedParents.includes(parentId)) {
                                     addedParents.push(parentId);
                                     if (!graph.current.getNode(parentId)) {
@@ -119,8 +119,7 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
                     const highlightRegEx = highlightNodesRegEx();
 
                     for (const blockId in updatedMetadata) {
-                        const noPrefixId = HexHelper.stripPrefix(blockId);
-                        const node = graph.current.getNode(noPrefixId);
+                        const node = graph.current.getNode(blockId);
                         if (node) {
                             if (node.data) {
                                 node.data.feedItem.metadata = {
@@ -356,8 +355,8 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
             graph.current?.forEachNode((n: Viva.Graph.INode<INodeData, unknown>) => {
                 const reattached = n.data?.feedItem;
                 if (reattached?.blockId !== feedItem?.blockId &&
-                    reattached?.transactionId &&
-                    reattached?.transactionId === feedItem.transactionId) {
+                    reattached?.properties?.transactionId &&
+                    reattached?.properties.transactionId === feedItem?.properties?.transactionId) {
                     feedItem.reattachments?.push(reattached);
                 }
             });
@@ -458,8 +457,10 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
         if (properties) {
             let key: keyof typeof properties;
             for (key in properties) {
-                const val = properties[key] as string;
-                if (typeof val === "string" && Converter.isHex(val, true) && regEx.test(Converter.hexToUtf8(val))) {
+                const val = String(properties[key]);
+                if (regEx.test(val) ||
+                    (Converter.isHex(val, true) && regEx.test(Converter.hexToUtf8(val)))
+                ) {
                     return true;
                 }
             }

--- a/client/src/helpers/hooks/useVisualizerState.tsx
+++ b/client/src/helpers/hooks/useVisualizerState.tsx
@@ -454,10 +454,11 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
         if (regEx.test(nodeId)) {
             return true;
         }
-
-        if (data.feedItem) {
-            for (const key in data.feedItem.properties) {
-                const val = data.feedItem.properties[key] as string;
+        const properties = data.feedItem.properties;
+        if (properties) {
+            let key: keyof typeof properties;
+            for (key in properties) {
+                const val = properties[key] as string;
                 if (typeof val === "string" && Converter.isHex(val, true) && regEx.test(Converter.hexToUtf8(val))) {
                     return true;
                 }

--- a/client/src/helpers/hooks/useVisualizerState.tsx
+++ b/client/src/helpers/hooks/useVisualizerState.tsx
@@ -19,7 +19,7 @@ const COLOR_REFERENCED: string = "0x61e884";
 const COLOR_CONFLICTING: string = "0xff8b5c";
 const COLOR_INCLUDED: string = "0x4caaff";
 const COLOR_MILESTONE: string = "0x666af6";
-const COLOR_SEARCH_RESULT: string = "0xe79c18";
+const COLOR_SEARCH_RESULT: string = "0xC061E8";
 
 /**
  * Setup the Visualizer state and ook into feed service for visalizer data.
@@ -58,6 +58,7 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
 
     useEffect(() => {
         window.addEventListener("resize", resize);
+        window.addEventListener("theme-change", toggleDarkMode);
         setupGraph();
 
         return () => {
@@ -69,6 +70,7 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
             renderer.current = null;
             existingIds.current = [];
             window.removeEventListener("resize", resize);
+            window.removeEventListener("theme-change", toggleDarkMode);
         };
     }, [graphElement, network]);
 
@@ -146,6 +148,10 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
         restyleNodes();
         selectedFeedItemBlockId.current = selectedFeedItem?.blockId ?? null;
     }, [filter, selectedFeedItem]);
+
+    useEffect(() => {
+        styleConnections();
+    }, [darkMode]);
 
     /**
      * Setup the graph.
@@ -495,9 +501,13 @@ export function useVisualizerState(network: string, graphElement: React.MutableR
         setIsActive(!isActive);
     }
 
-    if (darkMode !== settingsService.get().darkMode) {
-        setDarkMode(settingsService.get().darkMode ?? null);
-        styleConnections();
+    /**
+     * Toggle dark mode
+     * @param event The theme-change event.
+     */
+    function toggleDarkMode(event: Event): void {
+        const dMode = (event as CustomEvent).detail.darkMode as boolean;
+        setDarkMode(dMode);
     }
 
     return [

--- a/client/src/models/api/stardust/feed/IFeedBlockData.ts
+++ b/client/src/models/api/stardust/feed/IFeedBlockData.ts
@@ -5,7 +5,7 @@ export interface IFeedBlockProperties {
     index?: number;
     tag?: HexEncodedString;
     timestamp?: number;
-    milestoneId?: string;
+    milestoneId?: HexEncodedString;
     transactionId?: HexEncodedString;
 }
 
@@ -26,7 +26,7 @@ export interface IFeedBlockData {
     parents?: string[];
 
     /**
-     * Metadata for the item.
+     * The feed block properties.
      */
     properties?: IFeedBlockProperties;
 

--- a/client/src/models/api/stardust/feed/IFeedBlockData.ts
+++ b/client/src/models/api/stardust/feed/IFeedBlockData.ts
@@ -1,6 +1,13 @@
 import { HexEncodedString } from "@iota/iota.js-stardust";
 import { IFeedBlockMetadata } from "./IFeedBlockMetadata";
 
+export interface IFeedBlockProperties {
+    index?: number;
+    tag?: HexEncodedString;
+    timestamp?: number;
+    milestoneId?: string;
+}
+
 export interface IFeedBlockData {
     /**
      * The block id.
@@ -20,7 +27,7 @@ export interface IFeedBlockData {
     /**
      * Metadata for the item.
      */
-    properties?: { [key: string]: unknown };
+    properties?: IFeedBlockProperties;
 
     /**
      * The transaction id.

--- a/client/src/models/api/stardust/feed/IFeedBlockData.ts
+++ b/client/src/models/api/stardust/feed/IFeedBlockData.ts
@@ -6,6 +6,7 @@ export interface IFeedBlockProperties {
     tag?: HexEncodedString;
     timestamp?: number;
     milestoneId?: string;
+    transactionId?: HexEncodedString;
 }
 
 export interface IFeedBlockData {
@@ -28,11 +29,6 @@ export interface IFeedBlockData {
      * Metadata for the item.
      */
     properties?: IFeedBlockProperties;
-
-    /**
-     * The transaction id.
-     */
-    transactionId?: HexEncodedString;
 
     /**
      * The blocks with same transaction id (reattached transaction).

--- a/client/src/models/api/stardust/feed/IFeedBlockData.ts
+++ b/client/src/models/api/stardust/feed/IFeedBlockData.ts
@@ -1,3 +1,4 @@
+import { HexEncodedString } from "@iota/iota.js-stardust";
 import { IFeedBlockMetadata } from "./IFeedBlockMetadata";
 
 export interface IFeedBlockData {
@@ -20,6 +21,16 @@ export interface IFeedBlockData {
      * Metadata for the item.
      */
     properties?: { [key: string]: unknown };
+
+    /**
+     * The transaction id.
+     */
+    transactionId?: HexEncodedString;
+
+    /**
+     * The blocks with same transaction id (reattached transaction).
+     */
+    reattachments?: IFeedBlockData[];
 
     /**
      * The payload type for Stardust.

--- a/client/src/services/stardust/stardustFeedClient.ts
+++ b/client/src/services/stardust/stardustFeedClient.ts
@@ -210,7 +210,7 @@ export class StardustFeedClient {
                 }
 
                 if (block.payload.essence.payload) {
-                    properties.Index = block.payload.essence.payload.tag;
+                    properties.tag = block.payload.essence.payload.tag;
                 }
             } else if (block.payload?.type === MILESTONE_PAYLOAD_TYPE) {
                 payloadType = "Milestone";
@@ -219,7 +219,7 @@ export class StardustFeedClient {
                 properties.milestoneId = milestoneIdFromMilestonePayload(block.payload);
             } else if (block.payload?.type === TAGGED_DATA_PAYLOAD_TYPE) {
                 payloadType = "TaggedData";
-                properties.Index = block.payload.tag;
+                properties.tag = block.payload.tag;
             }
         } catch (err) {
             console.error(err);

--- a/client/src/services/stardust/stardustFeedClient.ts
+++ b/client/src/services/stardust/stardustFeedClient.ts
@@ -6,7 +6,8 @@ import {
     milestoneIdFromMilestonePayload,
     MILESTONE_PAYLOAD_TYPE,
     TAGGED_DATA_PAYLOAD_TYPE,
-    TRANSACTION_PAYLOAD_TYPE
+    TRANSACTION_PAYLOAD_TYPE,
+    TransactionHelper
 } from "@iota/iota.js-stardust";
 import { Converter, ReadStream } from "@iota/util.js-stardust";
 import { io, Socket } from "socket.io-client";
@@ -187,14 +188,18 @@ export class StardustFeedClient {
         const blockId = Converter.bytesToHex(Blake2b.sum256(bytes), true);
 
         let value;
+        let transactionId;
         let payloadType: "Transaction" | "TaggedData" | "Milestone" | "None" = "None";
         const properties: { [key: string]: unknown } = {};
         let block: IBlock | null = null;
 
         try {
             block = deserializeBlock(new ReadStream(bytes));
-
             if (block.payload?.type === TRANSACTION_PAYLOAD_TYPE) {
+                transactionId = Converter.bytesToHex(
+                    TransactionHelper.getTransactionPayloadHash(block.payload),
+                    true
+                );
                 payloadType = "Transaction";
                 value = 0;
 
@@ -225,6 +230,7 @@ export class StardustFeedClient {
             value,
             parents: block?.parents ?? [],
             properties,
+            transactionId,
             payloadType
         };
     }

--- a/client/src/services/stardust/stardustFeedClient.ts
+++ b/client/src/services/stardust/stardustFeedClient.ts
@@ -200,6 +200,7 @@ export class StardustFeedClient {
                     TransactionHelper.getTransactionPayloadHash(block.payload),
                     true
                 );
+                properties.transactionId = transactionId;
                 payloadType = "Transaction";
                 value = 0;
 
@@ -230,7 +231,6 @@ export class StardustFeedClient {
             value,
             parents: block?.parents ?? [],
             properties,
-            transactionId,
             payloadType
         };
     }


### PR DESCRIPTION

# Description of change

On the Visualizer page, when you choose a block containing a transaction payload, a list of associated blocks with reattached transactions will be displayed.
fixes #727 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
