### PR TITLE
Fix: Remove 400 responses from console for Alias/Nfts

### DIFF
--- a/api/src/models/api/stardust/IAliasResponse.ts
+++ b/api/src/models/api/stardust/IAliasResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../IResponse";
+import { IResponse } from "./IResponse";
 
 export interface IAliasResponse extends IResponse {
     /**

--- a/api/src/models/api/stardust/IOutputDetailsResponse.ts
+++ b/api/src/models/api/stardust/IOutputDetailsResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../IResponse";
+import { IResponse } from "./IResponse";
 
 export interface IOutputDetailsResponse extends IResponse {
     /**

--- a/api/src/models/api/stardust/IResponse.ts
+++ b/api/src/models/api/stardust/IResponse.ts
@@ -1,0 +1,11 @@
+export interface IResponse {
+    /**
+     * An error for the response.
+     */
+    error?: string;
+
+    /**
+     * A message for the response.
+     */
+    message?: string;
+}

--- a/api/src/models/api/stardust/foundry/IFoundriesResponse.ts
+++ b/api/src/models/api/stardust/foundry/IFoundriesResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputsResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface IFoundriesResponse extends IResponse {
     /**

--- a/api/src/models/api/stardust/foundry/IFoundryResponse.ts
+++ b/api/src/models/api/stardust/foundry/IFoundryResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface IFoundryResponse extends IResponse {
     /**

--- a/api/src/models/api/stardust/nft/INftDetailsResponse.ts
+++ b/api/src/models/api/stardust/nft/INftDetailsResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface INftDetailsResponse extends IResponse {
     /**

--- a/api/src/models/api/stats/IMilestoneAnalyticStats.ts
+++ b/api/src/models/api/stats/IMilestoneAnalyticStats.ts
@@ -1,4 +1,4 @@
-import { IResponse } from "../IResponse";
+import { IResponse } from "../stardust/IResponse";
 
 export interface IMilestoneAnalyticStats extends IResponse {
     milestoneIndex?: number;

--- a/api/src/routes/stardust/milestone/influx/get.ts
+++ b/api/src/routes/stardust/milestone/influx/get.ts
@@ -43,7 +43,7 @@ export async function get(
         blockCount: maybeMsStats.blockCount,
         perPayloadType: maybeMsStats.perPayloadType
     } : {
-        error: `Could not fetch milestone analytics for ${request.milestoneIndex}`
+        message: `Could not fetch milestone analytics for ${request.milestoneIndex}`
     };
 }
 

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -167,7 +167,7 @@ export class StardustTangleHelper {
 
         return outputResponse ?
             { output: outputResponse } :
-            { error: "Output not found" };
+            { message: "Output not found" };
     }
 
     /**
@@ -350,13 +350,15 @@ export class StardustTangleHelper {
             true
         );
 
-        if (aliasOutput.items.length > 0) {
+        if (aliasOutput?.items.length > 0) {
             const outputResponse = await this.outputDetails(network, aliasOutput.items[0]);
 
             return !outputResponse.error ?
                 { aliasDetails: outputResponse.output } :
                 { error: outputResponse.error };
         }
+
+        return { message: "Alias output not found" };
     }
 
     /**
@@ -383,7 +385,7 @@ export class StardustTangleHelper {
                 };
             }
 
-            return { error: "Foundry output not found" };
+            return { message: "Foundries output not found" };
         } catch { }
     }
 
@@ -404,13 +406,15 @@ export class StardustTangleHelper {
             true
         );
 
-        if (foundryOutput.items.length > 0) {
+        if (foundryOutput?.items.length > 0) {
             const outputResponse = await this.outputDetails(network, foundryOutput.items[0]);
 
             return !outputResponse.error ?
                 { foundryDetails: outputResponse.output } :
                 { error: outputResponse.error };
         }
+
+        return { message: "Foundry output not found" };
     }
 
     /**
@@ -465,7 +469,7 @@ export class StardustTangleHelper {
                     { error: outputResponse.error };
             }
 
-            return { error: "Nft output not found" };
+            return { message: "Nft output not found" };
         } catch { }
     }
 

--- a/client/src/helpers/hooks/useNftDetails.ts
+++ b/client/src/helpers/hooks/useNftDetails.ts
@@ -47,11 +47,11 @@ export function useNftDetails(network: string, nftId: string | null):
                     if (!response?.error) {
                         const output = response.nftDetails?.output as INftOutput;
 
-                        const metadataFeature = output.immutableFeatures?.find(
+                        const metadataFeature = output?.immutableFeatures?.find(
                             feature => feature.type === METADATA_FEATURE_TYPE
                         ) as IMetadataFeature;
 
-                        const issuerFeature = output.immutableFeatures?.find(
+                        const issuerFeature = output?.immutableFeatures?.find(
                             feature => feature.type === ISSUER_FEATURE_TYPE
                         ) as IIssuerFeature;
 

--- a/client/src/models/api/stardust/IAliasResponse.ts
+++ b/client/src/models/api/stardust/IAliasResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../IResponse";
+import { IResponse } from "./IResponse";
 
 export interface IAliasResponse extends IResponse {
     /**

--- a/client/src/models/api/stardust/IOutputDetailsResponse.ts
+++ b/client/src/models/api/stardust/IOutputDetailsResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../IResponse";
+import { IResponse } from "./IResponse";
 
 export interface IOutputDetailsResponse extends IResponse {
     /**

--- a/client/src/models/api/stardust/IResponse.ts
+++ b/client/src/models/api/stardust/IResponse.ts
@@ -1,0 +1,11 @@
+export interface IResponse {
+    /**
+     * An error for the response.
+     */
+    error?: string;
+
+    /**
+     * A message for the response.
+     */
+    message?: string;
+}

--- a/client/src/models/api/stardust/foundry/IFoundriesResponse.ts
+++ b/client/src/models/api/stardust/foundry/IFoundriesResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputsResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface IFoundriesResponse extends IResponse {
     /**

--- a/client/src/models/api/stardust/foundry/IFoundryResponse.ts
+++ b/client/src/models/api/stardust/foundry/IFoundryResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface IFoundryResponse extends IResponse {
     /**

--- a/client/src/models/api/stardust/nft/INftDetailsResponse.ts
+++ b/client/src/models/api/stardust/nft/INftDetailsResponse.ts
@@ -1,5 +1,5 @@
 import { IOutputResponse } from "@iota/iota.js-stardust";
-import { IResponse } from "../../IResponse";
+import { IResponse } from "../IResponse";
 
 export interface INftDetailsResponse extends IResponse {
     /**

--- a/client/src/models/api/stats/IMilestoneAnalyticStats.ts
+++ b/client/src/models/api/stats/IMilestoneAnalyticStats.ts
@@ -1,4 +1,4 @@
-import { IResponse } from "../IResponse";
+import { IResponse } from "../stardust/IResponse";
 
 export interface IMilestoneAnalyticStats extends IResponse {
     milestoneIndex?: number;

--- a/client/src/services/stardust/stardustTangleCacheService.ts
+++ b/client/src/services/stardust/stardustTangleCacheService.ts
@@ -240,13 +240,13 @@ export class StardustTangleCacheService extends TangleCacheService {
         if (!this._stardustSearchCache[networkId][outputId]?.data?.output) {
             const response = await this._api.outputDetails({ network: networkId, outputId });
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[networkId][outputId] = {
                     data: { output: response.output },
                     cached: Date.now()
                 };
             } else {
-                return { error: response.error };
+                return { error: response.error ?? response.message };
             }
         }
 
@@ -425,7 +425,7 @@ export class StardustTangleCacheService extends TangleCacheService {
                 milestoneIndex
             });
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[networkId][key] = {
                     data: {
                         milestoneStats: response
@@ -519,13 +519,13 @@ export class StardustTangleCacheService extends TangleCacheService {
         if (!cacheEntry?.data?.aliasDetails || skipCache) {
             const response = await this._api.aliasDetails(request);
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[request.network][cacheKey] = {
                     data: { aliasDetails: response.aliasDetails },
                     cached: Date.now()
                 };
             } else {
-                return { error: response.error };
+                return { error: response.error ?? response.message };
             }
         }
 
@@ -550,13 +550,13 @@ export class StardustTangleCacheService extends TangleCacheService {
         if (!cacheEntry?.data?.foundryDetails || skipCache) {
             const response = await this._api.foundryDetails(request);
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[request.network][cacheKey] = {
                     data: { foundryDetails: response.foundryDetails },
                     cached: Date.now()
                 };
             } else {
-                return { error: response.error };
+                return { error: response.error ?? response.message };
             }
         }
 
@@ -581,13 +581,13 @@ export class StardustTangleCacheService extends TangleCacheService {
         if (!cacheEntry?.data?.foundryOutputs || skipCache) {
             const response = await this._api.aliasFoundries(request);
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[request.network][cacheKey] = {
                     data: { foundryOutputs: response.foundryOutputsResponse },
                     cached: Date.now()
                 };
             } else {
-                return { error: response.error };
+                return { error: response.error ?? response.message };
             }
         }
 
@@ -643,13 +643,13 @@ export class StardustTangleCacheService extends TangleCacheService {
         if (!cacheEntry?.data?.nftDetails || skipCache) {
             const response = await this._api.nftDetails(request);
 
-            if (!response.error) {
+            if (!response.error && !response.message) {
                 this._stardustSearchCache[request.network][cacheKey] = {
                     data: { nftDetails: response.nftDetails },
                     cached: Date.now()
                 };
             } else {
-                return { error: response.error };
+                return { error: response.error ?? response.message };
             }
         }
 


### PR DESCRIPTION
# Description of change

Added stardust `IResponse` model with `message` property that contains info message when the requested resource was not found. (eg. No output found)
Previously "Not found" message was return as `error` property which would than get delivered to fronted with status code 400 and get logged in the console.

fixes #705 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
