### PR TITLE
Fix: Word break in Data Toggle component

### DIFF
--- a/client/src/app/components/DataToggle.scss
+++ b/client/src/app/components/DataToggle.scss
@@ -24,7 +24,7 @@
   }
 
   .data-toggle--content {
-    word-break: break-all;
+    word-break: break-word;
 
     .json-viewer {
       max-height: 1000px;


### PR DESCRIPTION
# Description of change

Added `word-break` instead of `break-all` rule in Data toggle content.

fixes #764 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
