### PR TITLE
Update identity tool

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,11 +15,12 @@
                 "@iota/crypto.js-stardust": "npm:@iota/crypto.js@2.0.0-rc.2",
                 "@iota/identity-wasm": "^0.5.0-dev.6",
                 "@iota/identity-wasm-0.4": "npm:@iota/identity-wasm@^0.4.3",
-                "@iota/identity-wasm-0.7": "npm:@iota/identity-wasm@^0.7.0-alpha.3",
+                "@iota/identity-wasm-0.7": "npm:@iota/identity-wasm@^0.7.0-alpha.6",
                 "@iota/iota.js-chrysalis": "npm:@iota/iota.js@^1.8.6",
                 "@iota/iota.js-stardust": "npm:@iota/iota.js@2.0.0-rc.4",
                 "@iota/mqtt.js": "^1.8.6",
                 "@iota/mqtt.js-stardust": "npm:@iota/mqtt.js@2.0.0-rc.3",
+                "@iota/sdk-wasm": "^1.0.4",
                 "@iota/util.js": "^1.8.6",
                 "@iota/util.js-stardust": "npm:@iota/util.js@2.0.0-rc.2",
                 "@iota/validators": "^1.0.0-beta.30",
@@ -1029,11 +1030,11 @@
         },
         "node_modules/@iota/identity-wasm-0.7": {
             "name": "@iota/identity-wasm",
-            "version": "0.7.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/@iota/identity-wasm/-/identity-wasm-0.7.0-alpha.3.tgz",
-            "integrity": "sha512-rqgJLia2i2x8g2Y/lMHhok/Ha3FnO/x++k61a5T69+0yLwpzKmyrk+UUAuyyRb/w3pzhzwAKKRkG4aGRb9cAyg==",
+            "version": "0.7.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/@iota/identity-wasm/-/identity-wasm-0.7.0-alpha.6.tgz",
+            "integrity": "sha512-pZFrpRH+LFDJA+dhcmEkxWAIc8jezDVaCbv43Qws58IbhLG/hcm0CrWy32RV6dWz8VMRtWDB3ER8D323xiUG6g==",
             "dependencies": {
-                "@iota/types": "^1.0.0-beta.11",
+                "@noble/ed25519": "^1.7.3",
                 "@types/node-fetch": "^2.6.2",
                 "node-fetch": "^2.6.7"
             },
@@ -1041,37 +1042,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@iota/iota-client-wasm": "^0.5.0-alpha.5",
-                "@iota/iota.js": "^1.9.0-stardust.25"
-            }
-        },
-        "node_modules/@iota/iota-client-wasm": {
-            "version": "0.5.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/@iota/iota-client-wasm/-/iota-client-wasm-0.5.0-alpha.5.tgz",
-            "integrity": "sha512-FzyHMxBtwcPcCqLYk4um5pLk8KqCIWiSdE3c1bX4iTv0IH7EdM9G9js/GILFc2KlzWKYZK2L08xG0ogcrCPIHA==",
-            "peer": true,
-            "dependencies": {
-                "@iota/types": "^1.0.0-beta.11",
-                "node-fetch": "^2.6.7",
-                "text-encoding": "^0.7.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@iota/iota.js": {
-            "version": "1.9.0-stardust.28",
-            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.28.tgz",
-            "integrity": "sha512-SWI6OGH7aq7Kl7WG8y8DyFOfGI/sKHE6Z3O83cyNFZNh9EOYgBL39KQO1RNJK7jg4OVhcHv6h/GxAhVRhpWkyA==",
-            "peer": true,
-            "dependencies": {
-                "@iota/crypto.js": "next",
-                "@iota/util.js": "next",
-                "big-integer": "^1.6.51",
-                "node-fetch": "2.6.7"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "@iota/sdk-wasm": "^1.0.4"
             }
         },
         "node_modules/@iota/iota.js-chrysalis": {
@@ -1217,6 +1188,25 @@
             "version": "1.0.0-beta.30",
             "integrity": "sha512-fnhPMPul18WunLq9Ni4rxzBFmhna6eaG8WroDg6GdQqSK/eN62uFHV8tpspJHXuCqwgCUVp6NpuUna7+B2OV9g=="
         },
+        "node_modules/@iota/sdk-wasm": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@iota/sdk-wasm/-/sdk-wasm-1.0.5.tgz",
+            "integrity": "sha512-mFrKGPnM7DRd8AchTfE0+qcfhR2Vsy+9HaHITFxlw5YhGCLWis7dy5HQzrBESITaqhXejsQyZNThxp4zLak/Ew==",
+            "dependencies": {
+                "class-transformer": "^0.5.1",
+                "node-fetch": "^2.6.7",
+                "qs": "^6.9.7",
+                "reflect-metadata": "^0.1.13",
+                "semver": "^7.5.2",
+                "text-encoding": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.2"
+            }
+        },
         "node_modules/@iota/signing": {
             "version": "1.0.0-beta.30",
             "integrity": "sha512-VnOCBq8uAsMwQKv7VeYe2Yx2hTWxNp/lkNEqN6xgPsTII17elj0wjwR+b4euf48h3nIiGeCLWRK5a+k9r46o/g==",
@@ -1247,11 +1237,6 @@
                 "@iota/pad": "^1.0.0-beta.30",
                 "@iota/transaction": "^1.0.0-beta.30"
             }
-        },
-        "node_modules/@iota/types": {
-            "version": "1.0.0-beta.15",
-            "resolved": "https://registry.npmjs.org/@iota/types/-/types-1.0.0-beta.15.tgz",
-            "integrity": "sha512-67DrzDO5bl2c7RIMpOdtjdOa27Bv1EmX/BHPTQD8c3RtPPAzJpSIpuI8JsIDl3U6Qe4zdLX3kRv9zGBXcr0fZA=="
         },
         "node_modules/@iota/util.js": {
             "version": "1.8.6",
@@ -1676,6 +1661,17 @@
             "engines": {
                 "node": ">=v12.0.0"
             }
+        },
+        "node_modules/@noble/ed25519": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+            "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -3006,6 +3002,11 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
+        },
+        "node_modules/class-transformer": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+            "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
@@ -4463,7 +4464,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -7727,6 +7727,11 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
         "node_modules/regexp-tree": {
             "version": "0.1.24",
             "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
@@ -7947,9 +7952,9 @@
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -8450,8 +8455,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
             "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
-            "deprecated": "no longer maintained",
-            "peer": true
+            "deprecated": "no longer maintained"
         },
         "node_modules/text-hex": {
             "version": "1.0.0",
@@ -9898,36 +9902,13 @@
             }
         },
         "@iota/identity-wasm-0.7": {
-            "version": "npm:@iota/identity-wasm@0.7.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/@iota/identity-wasm/-/identity-wasm-0.7.0-alpha.3.tgz",
-            "integrity": "sha512-rqgJLia2i2x8g2Y/lMHhok/Ha3FnO/x++k61a5T69+0yLwpzKmyrk+UUAuyyRb/w3pzhzwAKKRkG4aGRb9cAyg==",
+            "version": "npm:@iota/identity-wasm@0.7.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/@iota/identity-wasm/-/identity-wasm-0.7.0-alpha.6.tgz",
+            "integrity": "sha512-pZFrpRH+LFDJA+dhcmEkxWAIc8jezDVaCbv43Qws58IbhLG/hcm0CrWy32RV6dWz8VMRtWDB3ER8D323xiUG6g==",
             "requires": {
-                "@iota/types": "^1.0.0-beta.11",
+                "@noble/ed25519": "^1.7.3",
                 "@types/node-fetch": "^2.6.2",
                 "node-fetch": "^2.6.7"
-            }
-        },
-        "@iota/iota-client-wasm": {
-            "version": "0.5.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/@iota/iota-client-wasm/-/iota-client-wasm-0.5.0-alpha.5.tgz",
-            "integrity": "sha512-FzyHMxBtwcPcCqLYk4um5pLk8KqCIWiSdE3c1bX4iTv0IH7EdM9G9js/GILFc2KlzWKYZK2L08xG0ogcrCPIHA==",
-            "peer": true,
-            "requires": {
-                "@iota/types": "^1.0.0-beta.11",
-                "node-fetch": "^2.6.7",
-                "text-encoding": "^0.7.0"
-            }
-        },
-        "@iota/iota.js": {
-            "version": "1.9.0-stardust.28",
-            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.28.tgz",
-            "integrity": "sha512-SWI6OGH7aq7Kl7WG8y8DyFOfGI/sKHE6Z3O83cyNFZNh9EOYgBL39KQO1RNJK7jg4OVhcHv6h/GxAhVRhpWkyA==",
-            "peer": true,
-            "requires": {
-                "@iota/crypto.js": "next",
-                "@iota/util.js": "next",
-                "big-integer": "^1.6.51",
-                "node-fetch": "2.6.7"
             }
         },
         "@iota/iota.js-chrysalis": {
@@ -10046,6 +10027,20 @@
             "version": "1.0.0-beta.30",
             "integrity": "sha512-fnhPMPul18WunLq9Ni4rxzBFmhna6eaG8WroDg6GdQqSK/eN62uFHV8tpspJHXuCqwgCUVp6NpuUna7+B2OV9g=="
         },
+        "@iota/sdk-wasm": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@iota/sdk-wasm/-/sdk-wasm-1.0.5.tgz",
+            "integrity": "sha512-mFrKGPnM7DRd8AchTfE0+qcfhR2Vsy+9HaHITFxlw5YhGCLWis7dy5HQzrBESITaqhXejsQyZNThxp4zLak/Ew==",
+            "requires": {
+                "class-transformer": "^0.5.1",
+                "fsevents": "^2.3.2",
+                "node-fetch": "^2.6.7",
+                "qs": "^6.9.7",
+                "reflect-metadata": "^0.1.13",
+                "semver": "^7.5.2",
+                "text-encoding": "^0.7.0"
+            }
+        },
         "@iota/signing": {
             "version": "1.0.0-beta.30",
             "integrity": "sha512-VnOCBq8uAsMwQKv7VeYe2Yx2hTWxNp/lkNEqN6xgPsTII17elj0wjwR+b4euf48h3nIiGeCLWRK5a+k9r46o/g==",
@@ -10076,11 +10071,6 @@
                 "@iota/pad": "^1.0.0-beta.30",
                 "@iota/transaction": "^1.0.0-beta.30"
             }
-        },
-        "@iota/types": {
-            "version": "1.0.0-beta.15",
-            "resolved": "https://registry.npmjs.org/@iota/types/-/types-1.0.0-beta.15.tgz",
-            "integrity": "sha512-67DrzDO5bl2c7RIMpOdtjdOa27Bv1EmX/BHPTQD8c3RtPPAzJpSIpuI8JsIDl3U6Qe4zdLX3kRv9zGBXcr0fZA=="
         },
         "@iota/util.js": {
             "version": "1.8.6",
@@ -10418,6 +10408,11 @@
             "requires": {
                 "lodash": "^4.17.21"
             }
+        },
+        "@noble/ed25519": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+            "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -11435,6 +11430,11 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
+        },
+        "class-transformer": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+            "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
         },
         "clean-regexp": {
             "version": "1.0.0",
@@ -12569,7 +12569,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "optional": true
         },
         "function-bind": {
@@ -14992,6 +14991,11 @@
                 "picomatch": "^2.2.1"
             }
         },
+        "reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
         "regexp-tree": {
             "version": "0.1.24",
             "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
@@ -15134,9 +15138,9 @@
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -15543,8 +15547,7 @@
         "text-encoding": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-            "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
-            "peer": true
+            "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
         },
         "text-hex": {
             "version": "1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -31,7 +31,7 @@
         "@iota/crypto.js-stardust": "npm:@iota/crypto.js@2.0.0-rc.2",
         "@iota/identity-wasm": "^0.5.0-dev.6",
         "@iota/identity-wasm-0.4": "npm:@iota/identity-wasm@^0.4.3",
-        "@iota/identity-wasm-0.7": "npm:@iota/identity-wasm@^0.7.0-alpha.3",
+        "@iota/identity-wasm-0.7": "npm:@iota/identity-wasm@^0.7.0-alpha.6",
         "@iota/iota.js-chrysalis": "npm:@iota/iota.js@^1.8.6",
         "@iota/iota.js-stardust": "npm:@iota/iota.js@2.0.0-rc.4",
         "@iota/mqtt.js": "^1.8.6",
@@ -55,7 +55,8 @@
         "socket.io": "^4.5.0",
         "uuid": "^8.3.2",
         "winston": "^3.8.2",
-        "zeromq": "^5.2.8"
+        "zeromq": "^5.2.8",
+        "@iota/sdk-wasm": "^1.0.4"
     },
     "devDependencies": {
         "@types/cors": "^2.8.12",


### PR DESCRIPTION
# Description of change
Update the identity resolver tool to work with the latest `0.7` release.

We have to add the `sdk-wasm` dependency as the identity library requires it. This can lead to the SDK being included twice, for Wasm and for Node.js once `iota-client` is replaced. 

Also the DID example should be changed to `did:iota:rms:0xabe51fb63206a02970378fcc2051884f12d33a39358e4fe8b4999c43d11fae7e` on testnet.


## Type of change

Choose a type of change, and delete any options that are not relevant.
- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested
resolve `did:iota:rms:0xabe51fb63206a02970378fcc2051884f12d33a39358e4fe8b4999c43d11fae7e` on testnet

