### PR TITLE
Fix: Resetting price stats on stardust landing page

### DIFF
--- a/client/src/helpers/hooks/useCurrencyService.ts
+++ b/client/src/helpers/hooks/useCurrencyService.ts
@@ -87,7 +87,7 @@ export function useCurrencyService(isIota: boolean): [
                     ) : "--"
             );
         }
-    }, [currency, currencyData]);
+    }, [isIota, currency, currencyData]);
 
     return [price, marketCap];
 }


### PR DESCRIPTION
# Description of change

Resetting price stats on stardust landing page when switching networks

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
