### PR TITLE
Fix: Show copy button for signatures

### DIFF
--- a/client/src/app/components/stardust/Unlocks.tsx
+++ b/client/src/app/components/stardust/Unlocks.tsx
@@ -51,13 +51,13 @@ const Unlocks: React.FC<IUnlocksProps> = ({ unlocks }) => {
                                         <div className="unlocks-card--row">
                                             <span className="label">Public Key:</span>
                                             <div className="value public-key">
-                                                <TruncatedId id={unlock.signature.publicKey} />
+                                                <TruncatedId id={unlock.signature.publicKey} showCopyButton />
                                             </div>
                                         </div>
                                         <div className="unlocks-card--row">
                                             <span className="label">Signature:</span>
                                             <div className="value signature">
-                                                <TruncatedId id={unlock.signature.signature} />
+                                                <TruncatedId id={unlock.signature.signature} showCopyButton />
                                             </div>
                                         </div>
                                     </div> :


### PR DESCRIPTION
# Description of change

 Show copy button for signatures in the Unlocks
resolves #792 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
