### PR TITLE
Feat: Reimplement play/pause in Visualizer

### DIFF
--- a/client/src/app/components/stardust/Visualizer/Wrapper.tsx
+++ b/client/src/app/components/stardust/Visualizer/Wrapper.tsx
@@ -11,23 +11,23 @@ export const Wrapper = ({
     blocksCount,
     children,
     filter,
-    isActive,
+    isPlaying,
     network,
     networkConfig,
     onChangeFilter,
     selectNode,
     selectedFeedItem,
-    toggleActivity
+    setIsPlaying
 }: {
     blocksCount: number;
     children: React.ReactNode; filter: string;
-    isActive: boolean;
+    isPlaying: boolean;
     network: string;
     networkConfig: INetwork;
     onChangeFilter: React.ChangeEventHandler<HTMLInputElement>;
     selectNode: TSelectNode;
     selectedFeedItem: TSelectFeedItem;
-    toggleActivity: () => void;
+    setIsPlaying: (isPlaying: boolean) => void;
 }) => (
     <div className="visualizer-stardust">
         <div className="row middle">
@@ -52,8 +52,8 @@ export const Wrapper = ({
             {children}
             <div className="action-panel-container">
                 <div className="card">
-                    <button className="pause-button" type="button" onClick={() => toggleActivity()}>
-                        {isActive
+                    <button className="pause-button" type="button" onClick={() => setIsPlaying(!isPlaying)}>
+                        {isPlaying
                                 ? <span className="material-icons">pause</span>
                                 : <span className="material-icons">play_arrow</span>}
                     </button>

--- a/client/src/app/routes/stardust/VisualizerDefault.tsx
+++ b/client/src/app/routes/stardust/VisualizerDefault.tsx
@@ -30,13 +30,13 @@ export const VisualizerDefault: React.FC<RouteComponentProps<VisualizerRouteProp
         <Wrapper
             blocksCount={blocksCount}
             filter={filter}
-            isActive={isActive}
+            isPlaying={isActive}
             network={network}
             networkConfig={networkConfig}
             onChangeFilter={e => setFilter(e.target.value)}
             selectNode={selectNode}
             selectedFeedItem={selectedFeedItem}
-            toggleActivity={toggleActivity}
+            setIsPlaying={toggleActivity}
         >
             <div
                 className="viva"

--- a/client/src/app/types/visualizer.types.ts
+++ b/client/src/app/types/visualizer.types.ts
@@ -7,11 +7,11 @@ export type TSelectNode = (node?: Viva.Graph.INode<INodeData, unknown>) => void;
 export type TSelectFeedItem = IFeedBlockData | null;
 
 export interface IVisualizerHookReturn {
-    toggleActivity: () => void;
+    setIsPlaying: (isPlaying: boolean) => void;
     selectNode: (node?: Viva.Graph.INode<INodeData, unknown>) => void;
     filter: string;
     setFilter: React.Dispatch<React.SetStateAction<string>>;
-    isActive: boolean;
+    isPlaying: boolean;
     blocksCount: number;
     selectedFeedItem: IFeedBlockData | null;
     isFormatAmountsFull: boolean | null;

--- a/client/src/features/visualizer-threejs/Emitter.tsx
+++ b/client/src/features/visualizer-threejs/Emitter.tsx
@@ -2,6 +2,7 @@ import { useFrame, useThree } from "@react-three/fiber";
 import React, { RefObject, Dispatch, SetStateAction, useEffect } from "react";
 import * as THREE from "three";
 import { useBorderPositions } from "./hooks/useBorderPositions";
+import { useBlockStore } from "./store";
 
 interface EmitterProps {
     setRunListeners: Dispatch<SetStateAction<boolean>>;
@@ -9,6 +10,8 @@ interface EmitterProps {
 }
 
 const Emitter = ({ setRunListeners, emitterRef }: EmitterProps) => {
+    const isPlaying = useBlockStore(state => state.isPlaying);
+
     useEffect(() => {
         if (emitterRef?.current) {
             setRunListeners(true);
@@ -22,6 +25,9 @@ const Emitter = ({ setRunListeners, emitterRef }: EmitterProps) => {
     const { halfScreenWidth } = useBorderPositions();
     const get = useThree(state => state.get);
     useFrame(() => {
+        if (!isPlaying) {
+            return;
+        }
         const camera = get().camera;
         const emitterObj = get().scene.getObjectByName("emitter");
         if (camera && emitterObj) {
@@ -34,6 +40,9 @@ const Emitter = ({ setRunListeners, emitterRef }: EmitterProps) => {
      * Emitter shift
      */
     useFrame((_, delta) => {
+        if (!isPlaying) {
+            return;
+        }
         if (emitterRef?.current) {
             const DELTA_MULTIPLIER = 80; // depends on this param we can manage speed of emitter
             emitterRef.current.position.x += delta * DELTA_MULTIPLIER;

--- a/client/src/features/visualizer-threejs/Emitter.tsx
+++ b/client/src/features/visualizer-threejs/Emitter.tsx
@@ -25,6 +25,7 @@ const Emitter = ({ setRunListeners, emitterRef }: EmitterProps) => {
     const { halfScreenWidth } = useBorderPositions();
     const get = useThree(state => state.get);
     useFrame(() => {
+        console.log("--- useFrame");
         if (!isPlaying) {
             return;
         }

--- a/client/src/features/visualizer-threejs/store.ts
+++ b/client/src/features/visualizer-threejs/store.ts
@@ -28,6 +28,9 @@ interface BlockStoreState {
 
     dimensions: { width: number; height: number };
     setDimensions: (width: number, height: number) => void;
+
+    isPlaying: boolean;
+    setIsPlaying: (isPlaying: boolean) => void;
 }
 
 export const useBlockStore = create<BlockStoreState>(set => ({
@@ -36,6 +39,7 @@ export const useBlockStore = create<BlockStoreState>(set => ({
     yPositions: {},
     zoom: ZOOM_DEFAULT,
     dimensions: { width: 0, height: 0 },
+    isPlaying: false,
 
     addBlock: (newBlock, options) => {
         set(state => {
@@ -129,5 +133,11 @@ export const useBlockStore = create<BlockStoreState>(set => ({
                 dimensions: { width, height }
             })
         );
+    },
+    setIsPlaying: isPlaying => {
+        set(state => ({
+            ...state,
+            isPlaying
+        }));
     }
 }));

--- a/client/src/features/visualizer-webgl/VisualizerWebgl.tsx
+++ b/client/src/features/visualizer-webgl/VisualizerWebgl.tsx
@@ -14,11 +14,11 @@ const VisualizerWebgl: React.FC<RouteComponentProps<VisualizerRouteProps>> = ({
     const graphElement = useRef<HTMLDivElement | null>(null);
 
     const {
-        toggleActivity,
+        setIsPlaying,
         selectNode,
         filter,
         setFilter,
-        isActive,
+        isPlaying,
         blocksCount,
         selectedFeedItem,
         // isFormatAmountsFull,
@@ -30,13 +30,13 @@ const VisualizerWebgl: React.FC<RouteComponentProps<VisualizerRouteProps>> = ({
         <Wrapper
             blocksCount={blocksCount}
             filter={filter}
-            isPlaying={isActive}
+            isPlaying={isPlaying}
             network={network}
             networkConfig={networkConfig}
             onChangeFilter={e => setFilter(e.target.value)}
             selectNode={selectNode}
             selectedFeedItem={selectedFeedItem}
-            setIsPlaying={toggleActivity}
+            setIsPlaying={setIsPlaying}
         >
             <div
                 className="viva"

--- a/client/src/features/visualizer-webgl/VisualizerWebgl.tsx
+++ b/client/src/features/visualizer-webgl/VisualizerWebgl.tsx
@@ -30,13 +30,13 @@ const VisualizerWebgl: React.FC<RouteComponentProps<VisualizerRouteProps>> = ({
         <Wrapper
             blocksCount={blocksCount}
             filter={filter}
-            isActive={isActive}
+            isPlaying={isActive}
             network={network}
             networkConfig={networkConfig}
-            onChangeFilter={(e) => setFilter(e.target.value)}
+            onChangeFilter={e => setFilter(e.target.value)}
             selectNode={selectNode}
             selectedFeedItem={selectedFeedItem}
-            toggleActivity={toggleActivity}
+            setIsPlaying={toggleActivity}
         >
             <div
                 className="viva"

--- a/client/src/features/visualizer-webgl/useVisualizerViva.ts
+++ b/client/src/features/visualizer-webgl/useVisualizerViva.ts
@@ -14,10 +14,10 @@ import { customLayout, THRESHOLD_PX } from "./layout";
 import { VivaNode } from "./vivagraph-layout.types";
 
 const MAX_ITEMS: number = 2500;
-const EDGE_COLOR_LIGHT: number = 0xb3b3b3cc;
-const EDGE_COLOR_DARK: number = 0xffffff33;
-const EDGE_COLOR_CONFIRMING: number = 0xff5aaaff;
-const EDGE_COLOR_CONFIRMED_BY: number = 0x0000ffff;
+const EDGE_COLOR_LIGHT: number = 0xB3B3B3CC;
+const EDGE_COLOR_DARK: number = 0xFFFFFF33;
+const EDGE_COLOR_CONFIRMING: number = 0xFF5AAAFF;
+const EDGE_COLOR_CONFIRMED_BY: number = 0x0000FFFF;
 const COLOR_PENDING: string = "0xbbbbbb";
 const COLOR_REFERENCED: string = "0x61e884";
 const COLOR_CONFLICTING: string = "0xff8b5c";
@@ -102,7 +102,7 @@ export function useVisualizerViva(
 
             graphics.current.setNodeProgram(buildNodeShader());
 
-            graphics.current.node((node) =>
+            graphics.current.node(node =>
                 calculateNodeStyle(
                     node,
                     testForHighlight(highlightNodesRegEx(), node.id, node.data)
@@ -121,7 +121,7 @@ export function useVisualizerViva(
             );
 
             // If click to node
-            events.click((node) => selectNode(node));
+            events.click(node => selectNode(node));
 
             // events.dblClick(node => {
             //     window.open(`${window.location.origin}/${network}/block/${node.id}`, "_blank");
@@ -369,7 +369,7 @@ export function useVisualizerViva(
             }
 
             const reattached = selectedFeedItem?.reattachments?.find(
-                (item) => item.blockId === node.data?.feedItem.blockId
+                item => item.blockId === node.data?.feedItem.blockId
             );
             if (
                 selectedFeedItem?.blockId === node.data?.feedItem.blockId ||
@@ -436,15 +436,16 @@ export function useVisualizerViva(
 
     /**
      * The pause button was clicked
+     * @param isPlaying
      */
-    function toggleActivity(): void {
-        if (isActive) {
+    function setIsPlaying(isPlaying: boolean): void {
+        if (isPlaying) {
             renderer.current?.pause();
         } else {
             renderer.current?.resume();
         }
 
-        setIsActive(!isActive);
+        setIsActive(isPlaying);
     }
 
     /**
@@ -578,11 +579,11 @@ export function useVisualizerViva(
     }
 
     return {
-        toggleActivity,
+        setIsPlaying,
         selectNode,
         filter,
         setFilter,
-        isActive,
+        isPlaying: isActive,
         blocksCount: itemCount,
         selectedFeedItem,
         isFormatAmountsFull,


### PR DESCRIPTION
# Description of change

Re-connect the pause button. On pause renderer should stop and useUpdateListener should stop listening for new blocks.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Feature

## How the change has been tested

Go to visualizer. Press "play" and "pause" buttons. Nodes should to stop and run again in accordance.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
