### PR TITLE
Fix: Search by TokenId

### DIFF
--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -203,8 +203,8 @@ export class SearchExecutor {
                         "foundryOutputId",
                         network
                     ).then(
-                        foundryOutputs => {
-                            if (foundryOutputs.length > 0) {
+                        foundryOutput => {
+                            if (foundryOutput) {
                                 promisesResult = {
                                     foundryId: searchQuery.foundryId
                                 };

--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -148,13 +148,13 @@ export class SearchExecutor {
         if (searchQuery.aliasId) {
             promises.push(
                 new Promise((resolve, reject) => {
-                    StardustTangleHelper.tryFetchNodeThenPermanode<string, IOutputsResponse>(
+                    StardustTangleHelper.tryFetchNodeThenPermanode<string, string>(
                         searchQuery.aliasId,
-                        "aliasOutputIds",
+                        "aliasOutputId",
                         network
                     ).then(
                         aliasOutputs => {
-                            if (aliasOutputs.items.length > 0) {
+                            if (aliasOutputs) {
                                 promisesResult = {
                                     aliasId: searchQuery.aliasId
                                 };
@@ -173,13 +173,13 @@ export class SearchExecutor {
         if (searchQuery.nftId) {
             promises.push(
                 new Promise((resolve, reject) => {
-                    StardustTangleHelper.tryFetchNodeThenPermanode<string, IOutputsResponse>(
+                    StardustTangleHelper.tryFetchNodeThenPermanode<string, string>(
                         searchQuery.nftId,
-                        "nftOutputIds",
+                        "nftOutputId",
                         network
                     ).then(
                         nftOutputs => {
-                            if (nftOutputs.items.length > 0) {
+                            if (nftOutputs) {
                                 promisesResult = {
                                     nftId: searchQuery.nftId
                                 };

--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -198,13 +198,13 @@ export class SearchExecutor {
         if (searchQuery.foundryId) {
             promises.push(
                 new Promise((resolve, reject) => {
-                    StardustTangleHelper.tryFetchNodeThenPermanode<string, IOutputsResponse>(
+                    StardustTangleHelper.tryFetchNodeThenPermanode<string, string>(
                         searchQuery.foundryId,
-                        "foundry",
+                        "foundryOutputId",
                         network
                     ).then(
                         foundryOutputs => {
-                            if (foundryOutputs.items.length > 0) {
+                            if (foundryOutputs.length > 0) {
                                 promisesResult = {
                                     foundryId: searchQuery.foundryId
                                 };

--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -127,7 +127,7 @@ export class SearchExecutor {
                 new Promise((resolve, reject) => {
                     StardustTangleHelper.tryFetchNodeThenPermanode<string, OutputResponse>(
                         searchQuery.output,
-                        "output",
+                        "outputIds",
                         network
                     ).then(
                         output => {
@@ -150,7 +150,7 @@ export class SearchExecutor {
                 new Promise((resolve, reject) => {
                     StardustTangleHelper.tryFetchNodeThenPermanode<string, IOutputsResponse>(
                         searchQuery.aliasId,
-                        "alias",
+                        "aliasOutputIds",
                         network
                     ).then(
                         aliasOutputs => {
@@ -175,7 +175,7 @@ export class SearchExecutor {
                 new Promise((resolve, reject) => {
                     StardustTangleHelper.tryFetchNodeThenPermanode<string, IOutputsResponse>(
                         searchQuery.nftId,
-                        "nft",
+                        "nftOutputIds",
                         network
                     ).then(
                         nftOutputs => {

--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -127,7 +127,7 @@ export class SearchExecutor {
                 new Promise((resolve, reject) => {
                     StardustTangleHelper.tryFetchNodeThenPermanode<string, OutputResponse>(
                         searchQuery.output,
-                        "outputIds",
+                        "getOutput",
                         network
                     ).then(
                         output => {

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-warning-comments */
 import {
+    __ClientMethods__,
     OutputResponse, Client, IBlockMetadata, MilestonePayload, IOutputsResponse,
     HexEncodedString, Block, Utils, QueryParameter, NftQueryParameter, AliasQueryParameter, FoundryQueryParameter
 } from "@iota/sdk";
@@ -29,6 +30,9 @@ import { IParticipationEventStatus } from "../../models/api/stardust/participati
 import { INetwork } from "../../models/db/INetwork";
 import { NodeInfoService } from "../../services/stardust/nodeInfoService";
 import { HexHelper } from "../hexHelper";
+
+type NameType<T> = T extends { name: infer U } ? U : never;
+type ExtractedMethodNames = NameType<__ClientMethods__>;
 
 /**
  * Helper functions for use with tangle.
@@ -598,7 +602,7 @@ export class StardustTangleHelper {
      */
     public static async tryFetchNodeThenPermanode<A, R>(
         args: A,
-        methodName: string,
+        methodName: ExtractedMethodNames,
         network: INetwork
     ): Promise<R> | null {
         const {

--- a/api/src/utils/stardust/stardustTangleHelper.ts
+++ b/api/src/utils/stardust/stardustTangleHelper.ts
@@ -618,7 +618,9 @@ export class StardustTangleHelper {
         } catch { }
 
         if (permaNodeEndpoint && isFallbackEnabled) {
-            const permanode = new Client({ nodes: [permaNodeEndpoint] });
+            // Client with permanode needs the ignoreNodeHealth as chronicle is considered "not healthy" by the sdk
+            // Related: https://github.com/iotaledger/inx-chronicle/issues/1302
+            const permanode = new Client({ nodes: [permaNodeEndpoint], ignoreNodeHealth: true });
 
             try {
                 // try fetch from permanode (chronicle)

--- a/client/src/app/routes/stardust/Search.tsx
+++ b/client/src/app/routes/stardust/Search.tsx
@@ -225,18 +225,7 @@ class Search extends AsyncComponent<RouteComponentProps<SearchRouteProps>, Searc
                                 query
                             });
 
-                            const isSearchResponseValid = response && Object.keys(response).length > 0;
-
-                            let foundryResponse;
-                            if (!isSearchResponseValid) {
-                                const foundryQuery = HexHelper.addPrefix(query);
-                                foundryResponse = await this._apiClient.foundryDetails({
-                                    network: this.props.match.params.network,
-                                    foundryId: foundryQuery
-                                });
-                            }
-
-                            if (isSearchResponseValid || foundryResponse?.foundryDetails) {
+                            if (response && Object.keys(response).length > 0) {
                                 let route = "";
                                 let routeParam = query;
                                 let redirectState = {};
@@ -275,9 +264,6 @@ class Search extends AsyncComponent<RouteComponentProps<SearchRouteProps>, Searc
                                 } else if (response.foundryId) {
                                     route = "foundry";
                                     routeParam = response.foundryId;
-                                } else if (foundryResponse?.foundryDetails) {
-                                    route = "foundry";
-                                    routeParam = query;
                                 } else if (response.nftId) {
                                     route = "addr";
                                     const nftAddress = this.buildAddressFromIdAndType(

--- a/client/src/app/routes/stardust/Search.tsx
+++ b/client/src/app/routes/stardust/Search.tsx
@@ -4,7 +4,6 @@ import { Redirect, RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
 import { scrollToTop } from "../../../helpers/pageUtils";
 import { Bech32AddressHelper } from "../../../helpers/stardust/bech32AddressHelper";
-import { HexHelper } from "../../../helpers/stardust/hexHelper";
 import { ProtocolVersion, STARDUST } from "../../../models/config/protocolVersion";
 import { NetworkService } from "../../../services/networkService";
 import { StardustApiClient } from "../../../services/stardust/stardustApiClient";


### PR DESCRIPTION
# Description of change

- Fixed searchExecutor to use the correct methods from SDK
- Added `ignoreNodeHealth` to all requests to chronicle as SDK considers it NotHealthy
 
fixes for #821.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Search address 0x082b58f55715a61e6b3db02374bdf1a3f09c2a836228738b27d2c180f44dcb91740100000000.
Before changes: it shows page 'not found'.
After changes: redirect to `foundry/0x082b58f55715a61e6b3db02374bdf1a3f09c2a836228738b27d2c180f44dcb91740100000000`
