### PR TITLE
chore: Add script to setup iota-sdk nova locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ config.local.feed.json
 config.staging.json
 config.prod.json
 env.js
+
+iota-sdk

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,6 +18,7 @@
                 "@iota/iota.js-chrysalis": "npm:@iota/iota.js@^1.8.6",
                 "@iota/mqtt.js": "^1.8.6",
                 "@iota/sdk": "1.1.1",
+                "@iota/sdk-nova": "../iota-sdk/bindings/nodejs",
                 "@iota/sdk-wasm": "^1.0.4",
                 "@iota/util.js": "^1.8.6",
                 "@iota/validators": "^1.0.0-beta.30",
@@ -59,6 +60,38 @@
             },
             "engines": {
                 "node": ">=16 <=16.20.2"
+            }
+        },
+        "../iota-sdk/bindings/nodejs": {
+            "name": "@iota/sdk",
+            "version": "1.1.3",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/node": "^18.15.12",
+                "class-transformer": "^0.5.1",
+                "prebuild-install": "^7.1.1",
+                "reflect-metadata": "^0.1.13",
+                "typescript": "^4.9.4"
+            },
+            "devDependencies": {
+                "@napi-rs/cli": "^1.0.0",
+                "@types/jest": "^29.4.0",
+                "@typescript-eslint/eslint-plugin": "^5.30.7",
+                "@typescript-eslint/parser": "^5.30.7",
+                "dotenv": "^16.0.3",
+                "electron-build-env": "^0.2.0",
+                "eslint": "^8.20.0",
+                "eslint-config-prettier": "^8.5.0",
+                "jest": "^29.4.2",
+                "jest-matcher-utils": "^29.5.0",
+                "prebuild": "^12.1.0",
+                "prettier": "^2.8.3",
+                "ts-jest": "^29.0.5",
+                "typedoc": "^0.24.6",
+                "typedoc-plugin-markdown": "^3.14.0",
+                "webpack": "^5.88.2",
+                "webpack-cli": "^5.1.4"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1271,6 +1304,10 @@
                 "reflect-metadata": "^0.1.13",
                 "typescript": "^4.9.4"
             }
+        },
+        "node_modules/@iota/sdk-nova": {
+            "resolved": "../iota-sdk/bindings/nodejs",
+            "link": true
         },
         "node_modules/@iota/sdk-wasm": {
             "version": "1.1.1",
@@ -11271,6 +11308,33 @@
                         "undici-types": "~5.26.4"
                     }
                 }
+            }
+        },
+        "@iota/sdk-nova": {
+            "version": "file:../iota-sdk/bindings/nodejs",
+            "requires": {
+                "@napi-rs/cli": "^1.0.0",
+                "@types/jest": "^29.4.0",
+                "@types/node": "^18.15.12",
+                "@typescript-eslint/eslint-plugin": "^5.30.7",
+                "@typescript-eslint/parser": "^5.30.7",
+                "class-transformer": "^0.5.1",
+                "dotenv": "^16.0.3",
+                "electron-build-env": "^0.2.0",
+                "eslint": "^8.20.0",
+                "eslint-config-prettier": "^8.5.0",
+                "jest": "^29.4.2",
+                "jest-matcher-utils": "^29.5.0",
+                "prebuild": "^12.1.0",
+                "prebuild-install": "^7.1.1",
+                "prettier": "^2.8.3",
+                "reflect-metadata": "^0.1.13",
+                "ts-jest": "^29.0.5",
+                "typedoc": "^0.24.6",
+                "typedoc-plugin-markdown": "^3.14.0",
+                "typescript": "^4.9.4",
+                "webpack": "^5.88.2",
+                "webpack-cli": "^5.1.4"
             }
         },
         "@iota/sdk-wasm": {

--- a/api/package.json
+++ b/api/package.json
@@ -34,6 +34,7 @@
         "@iota/iota.js-chrysalis": "npm:@iota/iota.js@^1.8.6",
         "@iota/mqtt.js": "^1.8.6",
         "@iota/sdk": "1.1.1",
+        "@iota/sdk-nova": "../iota-sdk/bindings/nodejs",
         "@iota/sdk-wasm": "^1.0.4",
         "@iota/util.js": "^1.8.6",
         "@iota/validators": "^1.0.0-beta.30",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
                 "@iota/mam-legacy": "github:iotaledger/mam.js#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
                 "@iota/mam.js": "^1.6.2",
                 "@iota/sdk-wasm": "1.1.1",
+                "@iota/sdk-wasm-nova": "../iota-sdk/bindings/wasm",
                 "@iota/util.js": "^1.8.6",
                 "@react-three/drei": "^9.84.2",
                 "@react-three/fiber": "^8.14.2",
@@ -98,6 +99,50 @@
             "engines": {
                 "node": ">=16 <=16.20.2"
             }
+        },
+        "../iota-sdk/bindings/wasm": {
+            "name": "@iota/sdk-wasm",
+            "version": "1.1.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "class-transformer": "^0.5.1",
+                "node-fetch": "^2.6.7",
+                "qs": "^6.9.7",
+                "reflect-metadata": "^0.1.13",
+                "semver": "^7.5.2",
+                "text-encoding": "^0.7.0"
+            },
+            "devDependencies": {
+                "@types/jest": "^27.5.2",
+                "@typescript-eslint/eslint-plugin": "^5.31.0",
+                "@typescript-eslint/parser": "^5.31.0",
+                "copy-webpack-plugin": "^11.0.0",
+                "dotenv": "^16.0.1",
+                "eslint": "^8.20.0",
+                "eslint-config-prettier": "^8.5.0",
+                "fs-extra": "^10.1.0",
+                "jest": "^27.5.1",
+                "jest-matcher-utils": "^28.1.3",
+                "prettier": "^2.7.1",
+                "ts-jest": "^27.1.5",
+                "ts-node": "^10.9.1",
+                "typedoc": "^0.24.0",
+                "typedoc-plugin-markdown": "^3.13.4",
+                "typescript": "^4.7.4",
+                "wasm-opt": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.2"
+            }
+        },
+        "../iota-sdk/bindings/wasm/web": {
+            "name": "@iota/sdk-wasm",
+            "version": "1.1.1",
+            "extraneous": true,
+            "license": "Apache-2.0"
         },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
@@ -821,6 +866,10 @@
             "optionalDependencies": {
                 "fsevents": "^2.3.2"
             }
+        },
+        "node_modules/@iota/sdk-wasm-nova": {
+            "resolved": "../iota-sdk/bindings/wasm",
+            "link": true
         },
         "node_modules/@iota/sdk-wasm/node_modules/lru-cache": {
             "version": "6.0.0",
@@ -11573,6 +11622,35 @@
                 "yallist": {
                     "version": "4.0.0"
                 }
+            }
+        },
+        "@iota/sdk-wasm-nova": {
+            "version": "file:../iota-sdk/bindings/wasm",
+            "requires": {
+                "@types/jest": "^27.5.2",
+                "@typescript-eslint/eslint-plugin": "^5.31.0",
+                "@typescript-eslint/parser": "^5.31.0",
+                "class-transformer": "^0.5.1",
+                "copy-webpack-plugin": "^11.0.0",
+                "dotenv": "^16.0.1",
+                "eslint": "^8.20.0",
+                "eslint-config-prettier": "^8.5.0",
+                "fs-extra": "^10.1.0",
+                "fsevents": "^2.3.2",
+                "jest": "^27.5.1",
+                "jest-matcher-utils": "^28.1.3",
+                "node-fetch": "^2.6.7",
+                "prettier": "^2.7.1",
+                "qs": "^6.9.7",
+                "reflect-metadata": "^0.1.13",
+                "semver": "^7.5.2",
+                "text-encoding": "^0.7.0",
+                "ts-jest": "^27.1.5",
+                "ts-node": "^10.9.1",
+                "typedoc": "^0.24.0",
+                "typedoc-plugin-markdown": "^3.13.4",
+                "typescript": "^4.7.4",
+                "wasm-opt": "^1.4.0"
             }
         },
         "@iota/signing": {

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
         "@iota/mam-legacy": "github:iotaledger/mam.js#fddc95f60539b9a31a4db1b5b56e0dedb8994883",
         "@iota/mam.js": "^1.6.2",
         "@iota/sdk-wasm": "1.1.1",
+        "@iota/sdk-wasm-nova": "../iota-sdk/bindings/wasm",
         "@iota/util.js": "^1.8.6",
         "@react-three/drei": "^9.84.2",
         "@react-three/fiber": "^8.14.2",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "scripts": {
     "setup:client": "cd client && npm install && npm run postinstall",
     "setup:api": "cd api && npm install && npm run build-compile && npm run build-config",
-    "setup:dev": "npm run clear && npm run prepare && npm run setup:client && npm run setup:api",
+    "setup:dev": "npm run clear && npm run setup:sdk-nova-local && npm run prepare && npm run setup:client && npm run setup:api",
     "clear": "rimraf api/node_modules api/dist client/node_modules client/build",
     "dev": "concurrently 'cd api && npm run start-dev' 'cd client && npm run start'",
     "pre-push": "concurrently 'cd api && npm run build-compile && npm run build-lint && npm run build-config' 'cd client && npm run build'",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "setup:sdk-nova-local": "./setup_nova.sh"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",

--- a/setup_nova.sh
+++ b/setup_nova.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+SDK_DIR="iota-sdk"
+TARGET_COMMIT="8d3f742c07ea94669d6e7ab7f8a85fe9d48c7af8"
+
+if [ ! -d "$SDK_DIR" ]; then
+  git clone -b 2.0 git@github.com:iotaledger/iota-sdk.git
+  cd "./$SDK_DIR"
+else
+  echo "Pulling nova-sdk..."
+  cd "./$SDK_DIR"
+  git pull
+fi
+
+echo "Checking out nova-sdk commit $TARGET_COMMIT"
+git checkout "$TARGET_COMMIT"
+
+echo "Building nodejs bindings"
+cd "./bindings/nodejs"
+yarn
+yarn build
+
+echo "Building wasm bindings"
+cd "../wasm"
+yarn
+yarn build
+
+


### PR DESCRIPTION
# Description of change

- Add temporary convenient setup of local iota-sdk-nova for development

Needs `rust` installed to build SDK
It's hooked into `npm run setup:dev` on root package (takes a while, but only the first time)
You can also run it separately with `npm run setup:sdk-nova-local`

