### PR TITLE
feat: improve radius based on throughput

### DIFF
--- a/client/src/features/visualizer-threejs/VisualizerInstance.tsx
+++ b/client/src/features/visualizer-threejs/VisualizerInstance.tsx
@@ -6,10 +6,10 @@ import React, { useEffect, useRef } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import * as THREE from "three";
 import { Box3 } from "three";
-import { ACCEPTED_BLOCK_COLORS, DIRECTIONAL_LIGHT_INTENSITY, PENDING_BLOCK_COLOR, TIME_DIFF_COUNTER, VISUALIZER_BACKGROUND, ZOOM_DEFAULT } from "./constants";
+import { ACCEPTED_BLOCK_COLORS, DIRECTIONAL_LIGHT_INTENSITY, PENDING_BLOCK_COLOR, VISUALIZER_BACKGROUND, ZOOM_DEFAULT } from "./constants";
 import Emitter from "./Emitter";
 import { useTangleStore, useConfigStore } from "./store";
-import { getGenerateY, randomIntFromInterval, timer } from "./utils";
+import { getGenerateDynamicYZPosition, randomIntFromInterval,  } from "./utils";
 import { BPSCounter } from "./BPSCounter";
 import { VisualizerRouteProps } from "../../app/routes/VisualizerRouteProps";
 import { ServiceFactory } from "../../factories/serviceFactory";
@@ -27,15 +27,13 @@ const features = {
     cameraControls: true
 };
 
-const timerDiff = timer(TIME_DIFF_COUNTER);
-
 const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = ({
     match: {
         params: { network }
     }
 }) => {
     const [networkConfig] = useNetworkConfig(network);
-    const generateY = getGenerateY({ withRandom: true });
+    const generateYZPositions = getGenerateDynamicYZPosition({ withRandom: true });
     const themeMode = useGetThemeMode()
 
     const [runListeners, setRunListeners] = React.useState<boolean>(false);
@@ -54,7 +52,6 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
     const addBlock = useTangleStore(s => s.addToBlockQueue);
     const addToEdgeQueue = useTangleStore(s => s.addToEdgeQueue);
     const addToColorQueue = useTangleStore(s => s.addToColorQueue);
-    const addYPosition = useTangleStore(s => s.addYPosition);
     const blockMetadata = useTangleStore(s => s.blockMetadata);
     const indexToBlockId = useTangleStore(s => s.indexToBlockId);
 
@@ -132,14 +129,16 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
         const emitterObj = emitterRef.current;
         if (emitterObj && blockData) {
             const emitterBox = new Box3().setFromObject(emitterObj);
-            const secondsFromStart = timerDiff();
 
-            const Y = generateY(secondsFromStart, bpsCounter.getBPS());
+            const emitterCenter = new THREE.Vector3();
+            emitterBox.getCenter(emitterCenter);
+
+            const { y, z } = generateYZPositions(bpsCounter.getBPS(), emitterCenter);
 
             const targetPosition = {
                 x: randomIntFromInterval(emitterBox.min.x, emitterBox.max.x),
-                y: Y,
-                z: randomIntFromInterval(emitterBox.min.z, emitterBox.max.z),
+                y,
+                z,
             };
 
             bpsCounter.addBlock();
@@ -150,19 +149,11 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
             blockMetadata.set(blockData.blockId, blockData);
 
             addToEdgeQueue(blockData.blockId, blockData.parents ?? []);
-            addYPosition(Y);
-
-            const emitterCenter = new THREE.Vector3();
-            emitterBox.getCenter(emitterCenter);
 
             addBlock({
                 id: blockData.blockId,
                 color: PENDING_BLOCK_COLOR,
-                targetPosition: {
-                    x: targetPosition.x,
-                    y: targetPosition.y,
-                    z: targetPosition.z
-                },
+                targetPosition,
                 initPosition: {
                     x: emitterCenter.x,
                     y: emitterCenter.y,

--- a/client/src/features/visualizer-threejs/VisualizerInstance.tsx
+++ b/client/src/features/visualizer-threejs/VisualizerInstance.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import * as THREE from "three";
 import { Box3 } from "three";
-import { ACCEPTED_BLOCK_COLORS, DIRECTIONAL_LIGHT_INTENSITY, PENDING_BLOCK_COLOR, VISUALIZER_BACKGROUND, ZOOM_DEFAULT } from "./constants";
+import { ACCEPTED_BLOCK_COLORS, DIRECTIONAL_LIGHT_INTENSITY, PENDING_BLOCK_COLOR, VISUALIZER_BACKGROUND, X_POSITION_MULTIPLIER, ZOOM_DEFAULT } from "./constants";
 import Emitter from "./Emitter";
 import { useTangleStore, useConfigStore } from "./store";
 import { getGenerateDynamicYZPosition, randomIntFromInterval,  } from "./utils";
@@ -134,12 +134,11 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
             emitterBox.getCenter(emitterCenter);
 
             const { y, z } = generateYZPositions(bpsCounter.getBPS(), emitterCenter);
+            const minX = emitterBox.min.x - ((emitterBox.max.x - emitterBox.min.x) * X_POSITION_MULTIPLIER);
+            const maxX = emitterBox.max.x + ((emitterBox.max.x - emitterBox.min.x) * X_POSITION_MULTIPLIER);
 
-            const targetPosition = {
-                x: randomIntFromInterval(emitterBox.min.x, emitterBox.max.x),
-                y,
-                z,
-            };
+            const x = randomIntFromInterval(minX, maxX)
+            const targetPosition = { x, y, z };
 
             bpsCounter.addBlock();
             if (!bpsCounter.getBPS()) {

--- a/client/src/features/visualizer-threejs/constants.ts
+++ b/client/src/features/visualizer-threejs/constants.ts
@@ -67,3 +67,5 @@ export const MIN_BLOCK_NEAR_RADIUS = 20;
 
 export const MAX_POINT_RETRIES = 10;
 export const MAX_PREV_POINTS = 20;
+
+export const X_POSITION_MULTIPLIER = 3;

--- a/client/src/features/visualizer-threejs/constants.ts
+++ b/client/src/features/visualizer-threejs/constants.ts
@@ -2,7 +2,7 @@ import { Color } from "three";
 import { ThemeMode } from './enums';
 
 // steps
-export const STEP_Y_PX = 20;
+export const BLOCK_STEP_PX = 10;
 export const STEP_CAMERA_SHIFT_PX = 100;
 
 export const MAX_BLOCK_INSTANCES = 5000;
@@ -54,3 +54,16 @@ export const VISUALIZER_BACKGROUND: Record<ThemeMode, string> = {
 export const EMITTER_WIDTH = 30;
 export const EMITTER_HEIGHT = 250;
 export const EMITTER_DEPTH = 250;
+
+// conic emitter
+
+export const MIN_RADIUS = 100;
+export const MAX_RADIUS = 300;
+
+export const MIN_BLOCKS_PER_SECOND = 50;
+export const MAX_BLOCKS_PER_SECOND = 200;
+
+export const MIN_BLOCK_NEAR_RADIUS = 20;
+
+export const MAX_POINT_RETRIES = 10;
+export const MAX_PREV_POINTS = 20;

--- a/client/src/features/visualizer-threejs/store/tangle.ts
+++ b/client/src/features/visualizer-threejs/store/tangle.ts
@@ -53,10 +53,6 @@ interface TangleState {
     indexToBlockId: string[];
     updateBlockIdToIndex: (blockId: string, index: number) => void;
 
-    yPositions: { [k: number]: number };
-    addYPosition: (blockY: number) => void;
-    removeYPosition: (blockY: number) => void;
-
     zoom: number;
     setZoom: (zoom: number) => void;
 
@@ -79,7 +75,6 @@ export const useTangleStore = create<TangleState>()(devtools(set => ({
     blockMetadata: new Map(),
     blockIdToAnimationPosition: new Map(),
     indexToBlockId: [],
-    yPositions: {},
     zoom: ZOOM_DEFAULT,
     bps: 0,
     clickedInstanceId: null,
@@ -180,37 +175,6 @@ export const useTangleStore = create<TangleState>()(devtools(set => ({
             return {
                 ...state,
                 indexToBlockId: nextIndexToBlockId
-            };
-        });
-    },
-    addYPosition: blockY => {
-        const Y = Math.floor(Math.abs(blockY));
-
-        set(state => {
-            const nextYPositions = { ...state.yPositions };
-
-            const prevYCount = nextYPositions[Y] || 0;
-            nextYPositions[Y] = prevYCount + 1;
-            return {
-                ...state,
-                yPositions: nextYPositions
-            };
-        });
-    },
-    removeYPosition: blockY => {
-        const Y = Math.floor(Math.abs(blockY));
-
-        set(state => {
-            const nextYPositions = { ...state.yPositions };
-            const current = nextYPositions[Y];
-            if (current === 1) {
-                delete nextYPositions[Y];
-            } else {
-                nextYPositions[Y] -= 1;
-            }
-            return {
-                ...state,
-                yPositions: nextYPositions
             };
         });
     },

--- a/client/src/features/visualizer-threejs/utils.ts
+++ b/client/src/features/visualizer-threejs/utils.ts
@@ -1,4 +1,5 @@
-import { STEP_Y_PX, TIME_DIFF_COUNTER, SECOND } from "./constants";
+import { BLOCK_STEP_PX, MIN_BLOCKS_PER_SECOND, MAX_BLOCKS_PER_SECOND, MIN_RADIUS, MAX_RADIUS, MIN_BLOCK_NEAR_RADIUS, MAX_PREV_POINTS, MAX_POINT_RETRIES } from "./constants";
+import { Vector3 } from 'three';
 
 /**
  * Generates a random number within a specified range.
@@ -41,109 +42,107 @@ export const timer = (msCounter: number = 1000) => {
     };
 };
 
-/**
- * Y coordinate generator from zero coordinate to top and bottom
- * @yields {number} - Y coordinate
- * @returns {Generator<number>} - Y coordinate generator
- */
-export function* yCoordinateGenerator(): Generator<number> {
-    let count = 0;
-    let isPositive = true;
-
-    yield 0; // Initial value
-
-    while (true) {
-        const reset = yield isPositive ? count : -count;
-
-        if (reset) {
-            count = 0;
-            isPositive = true;
-        } else {
-            // Alternate between positive and negative
-            isPositive = !isPositive;
-
-            // Increase count after generating both a positive and negative pair
-            if (!isPositive) {
-                count++;
-            }
-        }
-    }
+interface IBlockTanglePosition {
+    y: number;
+    z: number;
 }
 
-const getMaxYPosition = (bps: number) => {
-    const blocksPerTick = bps / (SECOND / TIME_DIFF_COUNTER);
-    const maxYPerTick = blocksPerTick * STEP_Y_PX / 2; // divide 2 because we have values more than 0 and less
+/**
+ * Calculates the distance between two points.
+ * @returns the distance between two points.
+ */
+function distanceBetweenPoints(point1: IBlockTanglePosition , point2: IBlockTanglePosition): number {
+    const { z: z1, y: y1 } = point1;
+    const { z: z2, y: y2 }  = point2;
+    return Math.sqrt((y2 - y1) ** 2 + (z2 - z1) ** 2);
+}
 
-    return {
-        blocksPerTick,
-        maxYPerTick: maxYPerTick > 0 ? maxYPerTick : 1
-    };
-};
-const checkRules = (y: number, prev: number[]) => {
-    let passAllChecks = true;
-    if (prev.length === 0) {
+/**
+ * Calculates the radius of the circle based on the blocks per second.
+ * @returns the radius of the circle.
+ */
+function getLinearRadius(bps: number): number {
+    if (bps < MIN_BLOCKS_PER_SECOND) bps = MIN_BLOCKS_PER_SECOND;
+    if (bps > MAX_BLOCKS_PER_SECOND) bps = MAX_BLOCKS_PER_SECOND;
+
+    // Linear interpolation formula to find the radius
+    const radius = MIN_RADIUS + ((MAX_RADIUS - MIN_RADIUS) * (bps - MIN_BLOCKS_PER_SECOND) / (MAX_BLOCKS_PER_SECOND - MIN_BLOCKS_PER_SECOND));
+    return radius;
+}
+
+/**
+ * Generates a random point on a circle.
+ * @returns the random point on a circle.
+ */
+function getDynamicRandomYZPoints(bps: number, initialPosition: Vector3 = new Vector3(0, 0, 0)): IBlockTanglePosition {
+    const theta = Math.random() * (2 * Math.PI);
+
+    const maxRadius = getLinearRadius(bps);
+    const randomFactor = Math.random();
+    const radius = randomFactor * maxRadius;
+
+
+    const y = radius * Math.cos(theta) + initialPosition.y;
+    const z = radius * Math.sin(theta) + initialPosition.z;
+
+    return { y, z };
+}
+
+/**
+ * Checks if the point is far enough from the prevPoints.
+ * @returns true if the point is far enough from the prevPoints.
+ */
+function checkPassAllChecks(point: IBlockTanglePosition, prevPoints: IBlockTanglePosition[]): boolean {
+    if (prevPoints.length === 0) {
         return true;
     }
 
-    const nearRadius = 10;
-    const near = prev.some(prevY => {
-        const top = prevY + nearRadius;
-        const bottom = prevY - nearRadius;
-        return y < top && y > bottom;
-    });
+    return !prevPoints.some(prevPoint => distanceBetweenPoints(point, prevPoint) < MIN_BLOCK_NEAR_RADIUS);
+}
 
-    if (near) {
-        passAllChecks = false;
-    }
 
-    return passAllChecks;
-};
 
 /**
- * Create generator for Y coordinate
- * @param root0 - .
- * @param root0.withRandom - .
- * @returns - function that returns Y coordinate
+ * Retries to generate a point until it passes all the checks.
+ * @returns the point that passes all the checks.
  */
-export const getGenerateY = ({ withRandom }: {withRandom?: boolean} = {}): (shift: number, bps: number) => number => {
-    let currentShift = 1;
-    const generator = yCoordinateGenerator();
-    const prevY: number[] = [];
-    const limitPrevY = 5;
-    const LIMIT_BPS = 48;
-    const { maxYPerTick: defaultMaxYPerTick } = getMaxYPosition(LIMIT_BPS);
+function generateAValidRandomPoint(bps: number, initialPosition: Vector3, prevPoints: IBlockTanglePosition[]): IBlockTanglePosition {
+    let trialPoint: IBlockTanglePosition;
+    let passAllChecks = false;
+    let retries = 0;
 
-    return (shift: number, bps: number) => {
-        shift += 1; // This hack needs to avoid Y = 0 on the start of graph.
-        let Y = generator.next().value as number;
-        if (!currentShift || currentShift !== shift) {
-            Y = generator.next(true).value as number;
-            // update shift locally
-            currentShift = shift;
-        }
+    do {
+        trialPoint = getDynamicRandomYZPoints(bps, initialPosition);
+        passAllChecks = checkPassAllChecks(trialPoint, prevPoints);
+        retries++;
+    } while (!passAllChecks && retries < MAX_POINT_RETRIES);
 
-        if (bps < LIMIT_BPS) {
-            let randomY = randomNumberFromInterval(-defaultMaxYPerTick, defaultMaxYPerTick);
+    prevPoints.push(trialPoint);
+    if (prevPoints.length > MAX_PREV_POINTS) {
+        prevPoints.shift();
+    }
 
-            // check if not match with last value (and not near);
-            let passAllChecks = checkRules(randomY, prevY);
-            while (!passAllChecks) {
-                randomY = randomNumberFromInterval(-defaultMaxYPerTick, defaultMaxYPerTick);
-                passAllChecks = checkRules(randomY, prevY);
-            }
+    return trialPoint;
+}
 
-            prevY.push(randomY);
-            if (prevY.length > limitPrevY) {
-                prevY.shift();
-            }
-            return randomY;
-        }
 
+/**
+ * Gets a function to generate a random point on a circle.
+ * @returns the function to generate the random point on a circle.
+ */
+export function getGenerateDynamicYZPosition({ withRandom }: { withRandom: boolean }): typeof getDynamicRandomYZPoints {
+    const prevPoints: IBlockTanglePosition[] = [];
+    
+    return (bps: number, initialPosition: Vector3 = new Vector3(0, 0, 0)): IBlockTanglePosition => {
+        const validPoint = generateAValidRandomPoint(bps, initialPosition, prevPoints);
+        
         if (withRandom) {
-            const randomNumber = randomNumberFromInterval(0, STEP_Y_PX / 20);
-            Y += randomNumber;
+            const randomYNumber = randomNumberFromInterval(0, BLOCK_STEP_PX / 20);
+            const randomXNumber = randomNumberFromInterval(0, BLOCK_STEP_PX / 20);
+            validPoint.y += randomYNumber;
+            validPoint.z += randomXNumber;
         }
 
-        return Y * STEP_Y_PX;
+        return validPoint;
     };
-};
+}

--- a/client/src/features/visualizer-threejs/utils.ts
+++ b/client/src/features/visualizer-threejs/utils.ts
@@ -142,7 +142,7 @@ export function getGenerateDynamicYZPosition(): typeof getDynamicRandomYZPoints 
 
         return validPoint;
     };
-};
+}
 
 export function getNewSinusoidalPosition(time: number, amplitude: number): number {
     const period = HALF_WAVE_PERIOD_SECONDS * 2;


### PR DESCRIPTION
# Description of change

Fixes #891 
Improves the shape of the tangle so that not only the Y axis is positioned randomly, but the Z too, and randomize the X axis so blocks travel at different speeds. It also takes into account the starting position of the emitter so that the tangle moves when the emitter moves (for #941)

## Type of change

- Enhancement

## How the change has been tested

Use a custom network to test for 50 and 200 bps. The range of the radius is linear to the min and max blocks per second. For less blocks see mainnet.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
