### PR TITLE
Feat: Support metadata topics in nova visualizer

### DIFF
--- a/api/src/models/api/nova/feed/IFeedUpdate.ts
+++ b/api/src/models/api/nova/feed/IFeedUpdate.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
-import { Block } from "@iota/sdk-nova";
+import { Block, IBlockMetadata } from "@iota/sdk-nova";
 
 interface IFeedBlockUpdate {
     blockId: string;
@@ -10,4 +10,5 @@ interface IFeedBlockUpdate {
 export interface IFeedUpdate {
     subscriptionId: string;
     blockUpdate?: IFeedBlockUpdate;
+    blockMetadataUpdate?: IBlockMetadata;
 }

--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -38,7 +38,7 @@ import NovaOutputPage from "./routes/nova/OutputPage";
 import StardustSearch from "./routes/stardust/Search";
 import StardustStatisticsPage from "./routes/stardust/statistics/StatisticsPage";
 import StardustTransactionPage from "./routes/stardust/TransactionPage";
-// import { Visualizer as StardustVisualizer } from "./routes/stardust/Visualizer";
+import { Visualizer as StardustVisualizer } from "./routes/stardust/Visualizer";
 import NovaVisualizer from "../features/visualizer-threejs/VisualizerInstance";
 import StreamsV0 from "./routes/StreamsV0";
 import { StreamsV0RouteProps } from "./routes/StreamsV0RouteProps";
@@ -157,12 +157,7 @@ const buildAppRoutes = (protocolVersion: string, withNetworkContext: (wrappedCom
 
     const stardustRoutes = [
         <Route exact path="/:network" key={keys.next().value} component={StardustLanding} />,
-        <Route
-            path="/:network/visualizer/"
-            key={keys.next().value}
-            // component={StardustVisualizer}
-            component={NovaVisualizer}
-        />,
+        <Route path="/:network/visualizer/" key={keys.next().value} component={StardustVisualizer} />,
         <Route path="/:network/search/:query?" key={keys.next().value} component={StardustSearch} />,
         <Route path="/:network/addr/:address" key={keys.next().value} component={StardustAddressPage} />,
         <Route path="/:network/nft/:nftId" key={keys.next().value} component={NftRedirectRoute} />,

--- a/client/src/features/visualizer-threejs/VisualizerInstance.tsx
+++ b/client/src/features/visualizer-threejs/VisualizerInstance.tsx
@@ -206,8 +206,7 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
         if (!feedServiceRef.current) {
             return;
         }
-        const novaFeedService = feedServiceRef.current as NovaFeedClient;
-        novaFeedService.subscribeBlocks(onNewBlock, onBlockMetadataUpdate);
+        feedServiceRef.current.subscribeBlocks(onNewBlock, onBlockMetadataUpdate);
 
         bpsCounter.start();
         setIsPlaying(true);

--- a/client/src/features/visualizer-threejs/VisualizerInstance.tsx
+++ b/client/src/features/visualizer-threejs/VisualizerInstance.tsx
@@ -13,7 +13,7 @@ import {
     PENDING_BLOCK_COLOR,
     VISUALIZER_BACKGROUND,
     EMITTER_X_POSITION_MULTIPLIER,
-    TRANSACTION_STATE_TO_COLOR,
+    BLOCK_STATE_TO_COLOR,
 } from "./constants";
 import Emitter from "./Emitter";
 import { useTangleStore, useConfigStore } from "./store";
@@ -177,8 +177,8 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
     };
 
     function onBlockMetadataUpdate(metadataUpdate: IBlockMetadata): void {
-        if (metadataUpdate?.transactionMetadata) {
-            const selectedColor = TRANSACTION_STATE_TO_COLOR.get(metadataUpdate.transactionMetadata.transactionState);
+        if (metadataUpdate?.blockState) {
+            const selectedColor = BLOCK_STATE_TO_COLOR.get(metadataUpdate.blockState);
             if (selectedColor) {
                 addToColorQueue(metadataUpdate.blockId, selectedColor);
             }

--- a/client/src/features/visualizer-threejs/VisualizerInstance.tsx
+++ b/client/src/features/visualizer-threejs/VisualizerInstance.tsx
@@ -27,7 +27,7 @@ import { Wrapper } from "./wrapper/Wrapper";
 import { CanvasElement } from "./enums";
 import { useGetThemeMode } from "~/helpers/hooks/useGetThemeMode";
 import CameraControls from "./CameraControls";
-import { BlockBodyType, IBlockMetadata, ValidationBlockBody } from "@iota/sdk-wasm-nova/web";
+import { BasicBlockBody, IBlockMetadata } from "@iota/sdk-wasm-nova/web";
 import { IFeedBlockData } from "~/models/api/nova/feed/IFeedBlockData";
 import "./Visualizer.scss";
 
@@ -158,9 +158,14 @@ const VisualizerInstance: React.FC<RouteComponentProps<VisualizerRouteProps>> = 
 
             blockMetadata.set(blockData.blockId, blockData);
 
-            const isValidationBlock = blockData.block.body.type === BlockBodyType.Validation;
-            if (isValidationBlock) {
-                addToEdgeQueue(blockData.blockId, (blockData.block.body as ValidationBlockBody).strongParents ?? []);
+            // edges
+            const blockStrongParents = (blockData.block.body as BasicBlockBody).strongParents ?? [];
+            const blockWeakParents = (blockData.block.body as BasicBlockBody).weakParents ?? [];
+            if (blockStrongParents.length > 0) {
+                addToEdgeQueue(blockData.blockId, blockStrongParents);
+            }
+            if (blockWeakParents.length > 0) {
+                addToEdgeQueue(blockData.blockId, blockWeakParents);
             }
 
             addBlock({

--- a/client/src/features/visualizer-threejs/constants.ts
+++ b/client/src/features/visualizer-threejs/constants.ts
@@ -23,11 +23,14 @@ export const ANIMATION_TIME_SECONDS = 3;
 
 // colors
 export const PENDING_BLOCK_COLOR = new Color("#A6C3FC");
-export const APPROVED_BLOCK_COLOR = new Color("#0000DB");
+export const ACCEPTED_BLOCK_COLOR = new Color("#0101AB");
+export const CONFIRMED_BLOCK_COLOR = new Color("#0000DB");
 export const FINALIZED_BLOCK_COLOR = new Color("#0101FF");
-export const BLOCK_STATE_TO_COLOR = new Map<BlockState, Color>([
+// TODO Remove accepted state once is added to the SDK (missing)
+export const BLOCK_STATE_TO_COLOR = new Map<BlockState | "accepted", Color>([
     ["pending", PENDING_BLOCK_COLOR],
-    ["confirmed", APPROVED_BLOCK_COLOR],
+    ["accepted", ACCEPTED_BLOCK_COLOR],
+    ["confirmed", CONFIRMED_BLOCK_COLOR],
     ["finalized", FINALIZED_BLOCK_COLOR],
 ]);
 

--- a/client/src/features/visualizer-threejs/constants.ts
+++ b/client/src/features/visualizer-threejs/constants.ts
@@ -1,4 +1,4 @@
-import { TransactionState } from "@iota/sdk-wasm-nova/web";
+import { BlockState } from "@iota/sdk-wasm-nova/web";
 import { Color } from "three";
 import { ThemeMode } from "./enums";
 
@@ -23,13 +23,12 @@ export const ANIMATION_TIME_SECONDS = 3;
 
 // colors
 export const PENDING_BLOCK_COLOR = new Color("#A6C3FC");
-export const ACCEPTED_TRANSACTION_COLOR = new Color("#0101AB");
-export const APPROVED_TRANSACTION_COLOR = new Color("#0000DB");
-export const FINALIZED_TRANSACTION_COLOR = new Color("#0101FF");
-export const TRANSACTION_STATE_TO_COLOR = new Map<TransactionState, Color>([
-    ["accepted", ACCEPTED_TRANSACTION_COLOR],
-    ["confirmed", APPROVED_TRANSACTION_COLOR],
-    ["finalized", FINALIZED_TRANSACTION_COLOR],
+export const APPROVED_BLOCK_COLOR = new Color("#0000DB");
+export const FINALIZED_BLOCK_COLOR = new Color("#0101FF");
+export const BLOCK_STATE_TO_COLOR = new Map<BlockState, Color>([
+    ["pending", PENDING_BLOCK_COLOR],
+    ["confirmed", APPROVED_BLOCK_COLOR],
+    ["finalized", FINALIZED_BLOCK_COLOR],
 ]);
 
 // emitter

--- a/client/src/features/visualizer-threejs/constants.ts
+++ b/client/src/features/visualizer-threejs/constants.ts
@@ -1,3 +1,4 @@
+import { TransactionState } from "@iota/sdk-wasm-nova/web";
 import { Color } from "three";
 import { ThemeMode } from "./enums";
 
@@ -22,19 +23,14 @@ export const ANIMATION_TIME_SECONDS = 3;
 
 // colors
 export const PENDING_BLOCK_COLOR = new Color("#A6C3FC");
-
-export const ACCEPTED_BLOCK_COLORS = [new Color("#0101FF"), new Color("#0000DB"), new Color("#0101AB")];
-
-export const COLORS = [
-    new Color("#F0F4FF"),
-    new Color("#E0EAFF"),
-    new Color("#C8DAFE"),
-    PENDING_BLOCK_COLOR,
-    new Color("#82A5F8"),
-    new Color("#5C84FA"),
-    new Color("#2559F5"),
-    ...ACCEPTED_BLOCK_COLORS,
-];
+export const ACCEPTED_TRANSACTION_COLOR = new Color("#0101AB");
+export const APPROVED_TRANSACTION_COLOR = new Color("#0000DB");
+export const FINALIZED_TRANSACTION_COLOR = new Color("#0101FF");
+export const TRANSACTION_STATE_TO_COLOR = new Map<TransactionState, Color>([
+    ["accepted", ACCEPTED_TRANSACTION_COLOR],
+    ["confirmed", APPROVED_TRANSACTION_COLOR],
+    ["finalized", FINALIZED_TRANSACTION_COLOR],
+]);
 
 // emitter
 export const EMITTER_SPEED_MULTIPLIER = 80;

--- a/client/src/models/api/nova/feed/IFeedUpdate.ts
+++ b/client/src/models/api/nova/feed/IFeedUpdate.ts
@@ -1,4 +1,4 @@
-import { Block } from "@iota/sdk-wasm-nova/web";
+import { Block, IBlockMetadata } from "@iota/sdk-wasm-nova/web";
 
 interface IFeedBlockUpdate {
     blockId: string;
@@ -8,4 +8,5 @@ interface IFeedBlockUpdate {
 export interface IFeedUpdate {
     subscriptionId: string;
     blockUpdate?: IFeedBlockUpdate;
+    blockMetadataUpdate?: IBlockMetadata;
 }

--- a/client/src/services/nova/novaFeedClient.ts
+++ b/client/src/services/nova/novaFeedClient.ts
@@ -1,10 +1,10 @@
+import { IBlockMetadata } from "@iota/sdk-wasm-nova/web";
 import { io, Socket } from "socket.io-client";
 import { ServiceFactory } from "~/factories/serviceFactory";
 import { IFeedSubscribeResponse } from "~/models/api/IFeedSubscribeResponse";
 import { IFeedBlockData } from "~/models/api/nova/feed/IFeedBlockData";
 import { IFeedSubscribeRequest } from "~/models/api/nova/feed/IFeedSubscribeRequest";
 import { IFeedUpdate } from "~/models/api/nova/feed/IFeedUpdate";
-import { IFeedBlockMetadata } from "~/models/api/stardust/feed/IFeedBlockMetadata";
 import { IFeedUnsubscribeRequest } from "~/models/api/stardust/feed/IFeedUnsubscribeRequest";
 import { INetwork } from "~/models/config/INetwork";
 import { NetworkService } from "../networkService";
@@ -53,8 +53,7 @@ export class NovaFeedClient {
      */
     public subscribeBlocks(
         onBlockDataCallback?: (blockData: IFeedBlockData) => void,
-        // TODO Support metadata update when 'blocks-metadata' topic becomes supported
-        onMetadataUpdatedCallback?: (metadataUpdate: { [id: string]: IFeedBlockMetadata }) => void,
+        onMetadataUpdatedCallback?: (blockMetadata: IBlockMetadata) => void,
     ) {
         this.socket = io(this.endpoint, { upgrade: true, transports: ["websocket"] });
 
@@ -84,6 +83,10 @@ export class NovaFeedClient {
                     if (update.subscriptionId === this.blockSubscriptionId) {
                         if (update.blockUpdate) {
                             onBlockDataCallback?.(update.blockUpdate);
+                        }
+
+                        if (update.blockMetadataUpdate) {
+                            onMetadataUpdatedCallback?.(update.blockMetadataUpdate);
                         }
                     }
                 });


### PR DESCRIPTION
# Description of change

- Sets new Visualizer to be used only on Nova networks
- Listens to `block-metadata` topics and streams updates in novaFeed
- Colours Blocks in the Visualizer based on `TransactionState` 

Closes https://github.com/iotaledger/explorer/issues/1034

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

