### PR TITLE
feat: Improve expiration and timelock unlock conditions

### DIFF
--- a/client/src/app/components/nova/OutputView.scss
+++ b/client/src/app/components/nova/OutputView.scss
@@ -62,6 +62,23 @@
         }
     }
 
+    .unlock-condition-icon {
+        color: #fec900;
+        font-size: 18px;
+
+        &.expired {
+            color: #ff4800;
+        }
+
+        @media (min-width: #{768px}) and (max-width: #{820px}) {
+            display: none;
+        }
+
+        @include phone-down {
+            display: none;
+        }
+    }
+
     .left-border {
         border-left: 1px solid var(--border-color);
     }

--- a/client/src/app/components/nova/OutputView.tsx
+++ b/client/src/app/components/nova/OutputView.tsx
@@ -15,6 +15,11 @@ import {
     Utils,
     AccountAddress,
     NftAddress,
+    UnlockCondition,
+    UnlockConditionType,
+    StorageDepositReturnUnlockCondition,
+    ExpirationUnlockCondition,
+    TimelockUnlockCondition,
 } from "@iota/sdk-wasm-nova/web";
 import UnlockConditionView from "./UnlockConditionView";
 import CopyButton from "../CopyButton";
@@ -26,6 +31,10 @@ import { HexHelper } from "~/helpers/stardust/hexHelper";
 import bigInt from "big-integer";
 import { OutputManaDetails, getManaKeyValueEntries } from "~/helpers/nova/manaUtils";
 import KeyValueEntries from "./KeyValueEntries";
+import { hasSpecialCondition, isOutputExpired } from "~/helpers/nova/outputUtils";
+import Tooltip from "../Tooltip";
+import { useNovaTimeConvert } from "~/helpers/nova/hooks/useNovaTimeConvert";
+import { DateHelper } from "~/helpers/dateHelper";
 import "./OutputView.scss";
 
 interface OutputViewProps {
@@ -40,12 +49,30 @@ interface OutputViewProps {
 const OutputView: React.FC<OutputViewProps> = ({ outputId, output, showCopyAmount, isPreExpanded, isLinksDisabled, manaDetails }) => {
     const [isExpanded, setIsExpanded] = useState(isPreExpanded ?? false);
     const [isFormattedBalance, setIsFormattedBalance] = useState(true);
-    const { bech32Hrp, name: network } = useNetworkInfoNova((s) => s.networkInfo);
+    const { bech32Hrp, name: network, protocolInfo } = useNetworkInfoNova((s) => s.networkInfo);
+    const { slotIndexToUnixTimeRange } = useNovaTimeConvert();
 
     const accountOrNftBech32 = buildAddressForAccountOrNft(outputId, output, bech32Hrp);
     const outputIdTransactionPart = `${outputId.slice(0, 8)}....${outputId.slice(-8, -4)}`;
     const outputIdIndexPart = outputId.slice(-4);
     const manaEntries = manaDetails ? getManaKeyValueEntries(manaDetails) : undefined;
+    const isSpecialCondition = hasSpecialCondition(output as CommonOutput);
+
+    const specialUnlockCondition =
+        isSpecialCondition &&
+        (output as CommonOutput).unlockConditions.map((unlockCondition, idx) => {
+            const isExpired =
+                unlockCondition.type === UnlockConditionType.Expiration && (isOutputExpired(output as CommonOutput, protocolInfo) ?? false);
+            return (
+                <Tooltip key={idx} tooltipContent={getSpecialUnlockConditionContent(unlockCondition, slotIndexToUnixTimeRange, isExpired)}>
+                    <span className={classNames("material-icons unlock-condition-icon", { expired: isExpired })}>
+                        {unlockCondition.type === UnlockConditionType.StorageDepositReturn && "arrow_back"}
+                        {unlockCondition.type === UnlockConditionType.Expiration && "hourglass_bottom"}
+                        {unlockCondition.type === UnlockConditionType.Timelock && "schedule"}
+                    </span>
+                </Tooltip>
+            );
+        });
 
     const header = (
         <div onClick={() => setIsExpanded(!isExpanded)} className="card--value card-header--wrapper">
@@ -76,6 +103,7 @@ const OutputView: React.FC<OutputViewProps> = ({ outputId, output, showCopyAmoun
                     )
                     <CopyButton copy={String(outputId)} />
                 </div>
+                {specialUnlockCondition}
             </div>
             {showCopyAmount && (
                 <div className="card--value pointer amount-size row end">
@@ -252,6 +280,52 @@ function getOutputTypeName(type: OutputType): string {
             return "Nft";
         case OutputType.Delegation:
             return "Delegation";
+    }
+}
+
+/**
+ * Get tooltip content for special condition i.e SDRUC, EUC and TUC.
+ * @param unlockCondition Unlock condition of output.
+ * @returns The tooltip content.
+ */
+function getSpecialUnlockConditionContent(
+    unlockCondition: UnlockCondition,
+    slotIndexToUnixTimeRange:
+        | ((slotIndex: number) => {
+              from: number;
+              to: number;
+          })
+        | null,
+    isExpired: boolean,
+): React.ReactNode {
+    if (unlockCondition.type === UnlockConditionType.StorageDepositReturn) {
+        const storageDepositReturnUC = unlockCondition as StorageDepositReturnUnlockCondition;
+        return (
+            <React.Fragment>
+                <span>Storage Deposit Return Unlock Condition</span> <br />
+                <span>Return Amount: {storageDepositReturnUC.amount} glow</span>
+            </React.Fragment>
+        );
+    } else if (unlockCondition.type === UnlockConditionType.Expiration) {
+        const expirationUnlockCondition = unlockCondition as ExpirationUnlockCondition;
+        const slotTimeRange = slotIndexToUnixTimeRange ? slotIndexToUnixTimeRange(expirationUnlockCondition.slotIndex) : null;
+        const time = slotTimeRange ? DateHelper.format(DateHelper.milliseconds(slotTimeRange?.from)) : null;
+        return (
+            <React.Fragment>
+                <span>Expiration Unlock Condition{isExpired ? " (Expired)" : ""}</span> <br />
+                {time ? <span>Time: {time} </span> : <span>Slot: {expirationUnlockCondition.slotIndex}</span>}
+            </React.Fragment>
+        );
+    } else if (unlockCondition.type === UnlockConditionType.Timelock) {
+        const timelockUnlockCondition = unlockCondition as TimelockUnlockCondition;
+        const slotTimeRange = slotIndexToUnixTimeRange ? slotIndexToUnixTimeRange(timelockUnlockCondition.slotIndex) : null;
+        const time = slotTimeRange ? DateHelper.format(DateHelper.milliseconds(slotTimeRange?.from)) : null;
+        return (
+            <React.Fragment>
+                <span>Timelock Unlock Condition</span> <br />
+                {time ? <span>Time: {time} </span> : <span>Slot: {timelockUnlockCondition.slotIndex}</span>}
+            </React.Fragment>
+        );
     }
 }
 

--- a/client/src/helpers/nova/outputUtils.ts
+++ b/client/src/helpers/nova/outputUtils.ts
@@ -1,0 +1,43 @@
+import { CommonOutput, ExpirationUnlockCondition, ProtocolParametersResponse, UnlockConditionType } from "@iota/sdk-wasm-nova/web";
+import moment from "moment";
+import { unixTimestampToSlotIndexConverter } from "./novaTimeUtils";
+
+/**
+ * Check if output has special condition i.e SDRUC, EUC and TUC.
+ * @returns special condition exists.
+ */
+export function hasSpecialCondition(commonOutput: CommonOutput): boolean {
+    let specialUnlockConditionExists = false;
+
+    specialUnlockConditionExists = commonOutput.unlockConditions.some(
+        (condition) =>
+            condition.type === UnlockConditionType.StorageDepositReturn ||
+            condition.type === UnlockConditionType.Expiration ||
+            condition.type === UnlockConditionType.Timelock,
+    );
+
+    return specialUnlockConditionExists;
+}
+
+export function isOutputExpired(output: CommonOutput, nodeProtocolParameters: ProtocolParametersResponse | null): boolean | null {
+    const expirationUnlockCondition = output.unlockConditions.find(
+        (unlockCondition) => unlockCondition.type === UnlockConditionType.Expiration,
+    ) as ExpirationUnlockCondition;
+    const outputSlotIndex = expirationUnlockCondition?.slotIndex;
+    const maxCommittableAge = nodeProtocolParameters?.parameters?.maxCommittableAge ?? null;
+    const minCommittableAge = nodeProtocolParameters?.parameters?.minCommittableAge ?? null;
+
+    if (!nodeProtocolParameters || !outputSlotIndex || maxCommittableAge === null || minCommittableAge === null) return null;
+
+    const unixTimestampToSlotIndex = unixTimestampToSlotIndexConverter(nodeProtocolParameters);
+    const currentSlotIndex = unixTimestampToSlotIndex(moment().unix());
+
+    if (outputSlotIndex > currentSlotIndex + maxCommittableAge) {
+        return false;
+    } else if (outputSlotIndex <= currentSlotIndex + minCommittableAge) {
+        return true;
+    } else {
+        // The expiration is in the deadzone where it can't be unlocked
+        return null;
+    }
+}


### PR DESCRIPTION
# Description of change

- Added icons (with Tooltip) to OutputView for outputs with "special" unlock conditions
- Added outputUtils with capability of checking if an CommonOutput `isExpired` and `isTimeLocked`
- Color of icon depends if EUC is expired (or timelocked)

Closes https://github.com/iotaledger/explorer/issues/1087

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Need an Output with actual Expiration unlock condition to test this!! (Blocked)
- Need an Output with actual TimeLock unlock condition to test this!! (Blocked)

