### PR TITLE
fix: Reload address page state when address changes

### DIFF
--- a/client/src/helpers/nova/hooks/useAccountAddressState.ts
+++ b/client/src/helpers/nova/hooks/useAccountAddressState.ts
@@ -132,7 +132,7 @@ export const useAccountAddressState = (address: AccountAddress): [IAccountAddres
             ...initialState,
             addressDetails,
         });
-    }, []);
+    }, [address.accountId]);
 
     useEffect(() => {
         let updatedState: Partial<IAccountAddressState> = {

--- a/client/src/helpers/nova/hooks/useAnchorAddressState.ts
+++ b/client/src/helpers/nova/hooks/useAnchorAddressState.ts
@@ -91,7 +91,7 @@ export const useAnchorAddressState = (address: AnchorAddress): [IAnchorAddressSt
             ...initialState,
             addressDetails,
         });
-    }, []);
+    }, [address.anchorId]);
 
     useEffect(() => {
         setState({

--- a/client/src/helpers/nova/hooks/useEd25519AddressState.ts
+++ b/client/src/helpers/nova/hooks/useEd25519AddressState.ts
@@ -79,9 +79,10 @@ export const useEd25519AddressState = (address: Ed25519Address): [IEd25519Addres
             : { addressDetails: AddressHelper.buildAddress(bech32Hrp, address) };
 
         setState({
+            ...initialState,
             addressDetails,
         });
-    }, []);
+    }, [address.pubKeyHash]);
 
     useEffect(() => {
         setState({

--- a/client/src/helpers/nova/hooks/useImplicitAccountCreationAddressState.ts
+++ b/client/src/helpers/nova/hooks/useImplicitAccountCreationAddressState.ts
@@ -77,7 +77,7 @@ export const useImplicitAccountCreationAddressState = (
             ...initialState,
             addressDetails,
         });
-    }, []);
+    }, [address.address().pubKeyHash]);
 
     useEffect(() => {
         setState({

--- a/client/src/helpers/nova/hooks/useNftAddressState.ts
+++ b/client/src/helpers/nova/hooks/useNftAddressState.ts
@@ -91,7 +91,7 @@ export const useNftAddressState = (address: NftAddress): [INftAddressState, Reac
             ...initialState,
             addressDetails,
         });
-    }, []);
+    }, [address.nftId]);
 
     useEffect(() => {
         setState({


### PR DESCRIPTION
# Description of change

- Reinit specific address state when address changes

Closes https://github.com/iotaledger/explorer/issues/949 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Tested by going to an address with "Delegation Tab" (i.e. `rms1ppx2lkxeyuuuam9prh0mrr0p7ajs88v9npxvlereg0de4jwu2zvfuddjt6l`) and then clicking on one of the validator addresses (account addr -> account addr)
