### PR TITLE
feat: Use circulating supply from node endpoint

### DIFF
--- a/api/src/routes/networks/get.ts
+++ b/api/src/routes/networks/get.ts
@@ -2,6 +2,7 @@ import { ServiceFactory } from "../../factories/serviceFactory";
 import { INetworkGetResponse } from "../../models/api/INetworkGetResponse";
 import { IConfiguration } from "../../models/configuration/IConfiguration";
 import { NetworkService } from "../../services/networkService";
+import { NodeInfoService } from "../../services/stardust/nodeInfoService";
 
 /**
  * Get the networks.
@@ -19,28 +20,37 @@ export async function get(_: IConfiguration): Promise<INetworkGetResponse> {
             // and copy the fields needed by the client
             // as we don't want to expose all the information
             .filter((n) => !n.isHidden && n.isEnabled)
-            .map((n) => ({
-                network: n.network,
-                label: n.label,
-                protocolVersion: n.protocolVersion,
-                coordinatorAddress: n.coordinatorAddress,
-                coordinatorSecurityLevel: n.coordinatorSecurityLevel,
-                isEnabled: n.isEnabled,
-                showMarket: n.showMarket,
-                uiTheme: n.uiTheme,
-                hasStatisticsSupport:
-                    Boolean(n.analyticsInfluxDbEndpoint) &&
-                    Boolean(n.analyticsInfluxDbDatabase) &&
-                    Boolean(n.analyticsInfluxDbUsername) &&
-                    Boolean(n.analyticsInfluxDbPassword),
-                description: n.description,
-                bechHrp: n.bechHrp,
-                didExample: n.didExample,
-                faucet: n.faucet,
-                milestoneInterval: n.milestoneInterval,
-                circulatingSupply: n.circulatingSupply,
-                identityResolverEnabled: n.identityResolverEnabled,
-                tokenRegistryEndpoint: n.tokenRegistryEndpoint,
-            })),
+            .map((n) => {
+                const nodeInfoService = ServiceFactory.get<NodeInfoService>(`node-info-${n.network}`);
+                let circulatingSupplyFromSupplyTracker: number | null = null;
+
+                if (nodeInfoService) {
+                    circulatingSupplyFromSupplyTracker = nodeInfoService.circulatingSupply;
+                }
+
+                return {
+                    network: n.network,
+                    label: n.label,
+                    protocolVersion: n.protocolVersion,
+                    coordinatorAddress: n.coordinatorAddress,
+                    coordinatorSecurityLevel: n.coordinatorSecurityLevel,
+                    isEnabled: n.isEnabled,
+                    showMarket: n.showMarket,
+                    uiTheme: n.uiTheme,
+                    hasStatisticsSupport:
+                        Boolean(n.analyticsInfluxDbEndpoint) &&
+                        Boolean(n.analyticsInfluxDbDatabase) &&
+                        Boolean(n.analyticsInfluxDbUsername) &&
+                        Boolean(n.analyticsInfluxDbPassword),
+                    description: n.description,
+                    bechHrp: n.bechHrp,
+                    didExample: n.didExample,
+                    faucet: n.faucet,
+                    milestoneInterval: n.milestoneInterval,
+                    circulatingSupply: circulatingSupplyFromSupplyTracker ?? n.circulatingSupply,
+                    identityResolverEnabled: n.identityResolverEnabled,
+                    tokenRegistryEndpoint: n.tokenRegistryEndpoint,
+                };
+            }),
     };
 }

--- a/api/src/services/stardust/nodeInfoService.ts
+++ b/api/src/services/stardust/nodeInfoService.ts
@@ -1,6 +1,8 @@
 import { INodeInfoBaseToken, IRent, Client } from "@iota/sdk";
+import { StardustApiService } from "./stardustApiService";
 import { NodeInfoError } from "../../errors/nodeInfoError";
 import { ServiceFactory } from "../../factories/serviceFactory";
+import logger from "../../logger";
 import { INetwork } from "../../models/db/INetwork";
 
 /**
@@ -40,31 +42,57 @@ export class NodeInfoService {
     protected _nodeInfo: IReducedNodeInfo;
 
     /**
+     * The circulating supply of the network if available.
+     */
+    protected _ciruclatingSupply?: number | null;
+
+    /**
      * Create a new instance of NodeInfoService.
      * @param network The network config.
-     * @param nodeInfo The fetched node info
+     * @param nodeInfo The fetched node info.
+     * @param circulatingSupply The circulating supply of the network.
      */
-    private constructor(network: INetwork, nodeInfo: IReducedNodeInfo) {
+    private constructor(network: INetwork, nodeInfo: IReducedNodeInfo, circulatingSupply?: number | null) {
         this._network = network;
         this._nodeInfo = nodeInfo;
+        this._ciruclatingSupply = circulatingSupply ?? null;
+    }
+
+    public get circulatingSupply() {
+        return this._ciruclatingSupply;
     }
 
     public static async build(network: INetwork): Promise<NodeInfoService> {
         const apiClient = ServiceFactory.get<Client>(`client-${network.network}`);
+        const stardustApiService = ServiceFactory.get<StardustApiService>(`api-service-${network.network}`);
+        let nodeInfo: IReducedNodeInfo;
+        let circulatingSupply: number | null = null;
 
         try {
             const response = await apiClient.getInfo();
-            const nodeInfo = {
+            nodeInfo = {
                 baseToken: response.nodeInfo.baseToken,
                 protocolVersion: response.nodeInfo.protocol.version,
                 bech32Hrp: response.nodeInfo.protocol.bech32Hrp,
                 rentStructure: response.nodeInfo.protocol.rentStructure,
             };
-
-            return new NodeInfoService(network, nodeInfo);
         } catch (err) {
             throw new NodeInfoError(`Failed to fetch node info for "${network.network}" with error:\n${err}`);
         }
+
+        try {
+            const circulatingSupplyInBaseToken = await stardustApiService.circulatingSupply();
+            if (circulatingSupplyInBaseToken) {
+                // The circulating supply from inx-supply-tracker is returned in base token,
+                // so we format it to subunit
+                circulatingSupply = circulatingSupplyInBaseToken * Math.pow(10, nodeInfo.baseToken.decimals);
+                logger.debug(`[NodeInfoService] Circulating supply for ${network.network} (in subunit): ${circulatingSupply}`);
+            }
+        } catch {
+            logger.debug(`[NodeInfoService] Failed fetching circulating supply for ${network.network}`);
+        }
+
+        return new NodeInfoService(network, nodeInfo, circulatingSupply);
     }
 
     public getNodeInfo(): IReducedNodeInfo {

--- a/api/src/services/stardust/nodeInfoService.ts
+++ b/api/src/services/stardust/nodeInfoService.ts
@@ -1,9 +1,13 @@
 import { INodeInfoBaseToken, IRent, Client } from "@iota/sdk";
+import cron from "node-cron";
 import { StardustApiService } from "./stardustApiService";
 import { NodeInfoError } from "../../errors/nodeInfoError";
 import { ServiceFactory } from "../../factories/serviceFactory";
 import logger from "../../logger";
 import { INetwork } from "../../models/db/INetwork";
+
+// The cron interval value to update the circulating supply every 10 minutes.
+const CIRCULATING_SUPPLY_UPDATE_INTERVAL = "*/10 * * * *";
 
 /**
  * The reduced node info fields relevant for Explorer.
@@ -50,12 +54,12 @@ export class NodeInfoService {
      * Create a new instance of NodeInfoService.
      * @param network The network config.
      * @param nodeInfo The fetched node info.
-     * @param circulatingSupply The circulating supply of the network.
      */
-    private constructor(network: INetwork, nodeInfo: IReducedNodeInfo, circulatingSupply?: number | null) {
+    private constructor(network: INetwork, nodeInfo: IReducedNodeInfo) {
         this._network = network;
         this._nodeInfo = nodeInfo;
-        this._ciruclatingSupply = circulatingSupply ?? null;
+
+        this.setupCirculatingSupplyUpdater();
     }
 
     public get circulatingSupply() {
@@ -64,38 +68,51 @@ export class NodeInfoService {
 
     public static async build(network: INetwork): Promise<NodeInfoService> {
         const apiClient = ServiceFactory.get<Client>(`client-${network.network}`);
-        const stardustApiService = ServiceFactory.get<StardustApiService>(`api-service-${network.network}`);
-        let nodeInfo: IReducedNodeInfo;
-        let circulatingSupply: number | null = null;
 
         try {
             const response = await apiClient.getInfo();
-            nodeInfo = {
+            const nodeInfo = {
                 baseToken: response.nodeInfo.baseToken,
                 protocolVersion: response.nodeInfo.protocol.version,
                 bech32Hrp: response.nodeInfo.protocol.bech32Hrp,
                 rentStructure: response.nodeInfo.protocol.rentStructure,
             };
+
+            return new NodeInfoService(network, nodeInfo);
         } catch (err) {
             throw new NodeInfoError(`Failed to fetch node info for "${network.network}" with error:\n${err}`);
         }
+    }
+
+    public getNodeInfo(): IReducedNodeInfo {
+        return this._nodeInfo;
+    }
+
+    private setupCirculatingSupplyUpdater() {
+        // eslint-disable-next-line no-void
+        void this.updateCirculatingSupply();
+
+        cron.schedule(CIRCULATING_SUPPLY_UPDATE_INTERVAL, async () => {
+            await this.updateCirculatingSupply();
+        });
+    }
+
+    private async updateCirculatingSupply() {
+        const stardustApiService = ServiceFactory.get<StardustApiService>(`api-service-${this._network.network}`);
+        let circulatingSupply: number | null = null;
 
         try {
             const circulatingSupplyInBaseToken = await stardustApiService.circulatingSupply();
             if (circulatingSupplyInBaseToken) {
                 // The circulating supply from inx-supply-tracker is returned in base token,
                 // so we format it to subunit
-                circulatingSupply = circulatingSupplyInBaseToken * Math.pow(10, nodeInfo.baseToken.decimals);
-                logger.debug(`[NodeInfoService] Circulating supply for ${network.network} (in subunit): ${circulatingSupply}`);
+                circulatingSupply = circulatingSupplyInBaseToken * Math.pow(10, this._nodeInfo.baseToken.decimals);
+                logger.debug(`[NodeInfoService] Circulating supply for ${this._network.network} (in subunit): ${circulatingSupply}`);
+
+                this._ciruclatingSupply = circulatingSupply;
             }
         } catch {
-            logger.debug(`[NodeInfoService] Failed fetching circulating supply for ${network.network}`);
+            logger.debug(`[NodeInfoService] Failed fetching circulating supply for ${this._network.network}`);
         }
-
-        return new NodeInfoService(network, nodeInfo, circulatingSupply);
-    }
-
-    public getNodeInfo(): IReducedNodeInfo {
-        return this._nodeInfo;
     }
 }

--- a/api/src/services/stardust/stardustApiService.ts
+++ b/api/src/services/stardust/stardustApiService.ts
@@ -478,6 +478,19 @@ export class StardustApiService {
     }
 
     /**
+     * Get the circulating supply from inx-supply-tracking (in base token).
+     * @returns The circulating supply.
+     */
+    public async circulatingSupply(): Promise<number | null> {
+        const path: string = "api/supply/v1/";
+        const methodPath: string = "circulating";
+        const method = "GET";
+        const circulatingSupply: number | null = await this.nodePluginFetch<number | null>(path, method, methodPath);
+
+        return circulatingSupply;
+    }
+
+    /**
      * Find item on the stardust network.
      * @param query The query to use for finding items.
      * @returns The item found.


### PR DESCRIPTION
# Description of change

 - Use circulating supply from inx-supply-tracker in stardust networks if available (fallback to network config value)

Closes https://github.com/iotaledger/explorer/issues/1331

## Type of change

- Enhancement (a non-breaking change which adds functionality)

