### PR TITLE
feat: Add periodic updating of NodeInfo for nova

### DIFF
--- a/api/src/services/nova/nodeInfoService.ts
+++ b/api/src/services/nova/nodeInfoService.ts
@@ -1,9 +1,14 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Client, InfoResponse, ProtocolParameters } from "@iota/sdk-nova";
+import cron from "node-cron";
 import { NodeInfoError } from "../../errors/nodeInfoError";
 import { ServiceFactory } from "../../factories/serviceFactory";
+import logger from "../../logger";
 import { INetwork } from "../../models/db/INetwork";
+
+// The cron interval value to update the circulating supply every 10 minutes.
+const NODE_INFO_UPDATE_INTERVAL = "*/10 * * * *";
 
 /**
  * Class to handle Nova protocol node info.
@@ -34,6 +39,8 @@ export class NodeInfoService {
         this._network = network;
         this._nodeInfo = nodeInfo;
         this._client = client;
+
+        this.setupNodeInfoUpdater();
     }
 
     public static async build(network: INetwork): Promise<NodeInfoService> {
@@ -53,5 +60,31 @@ export class NodeInfoService {
 
     public async getProtocolParameters(): Promise<ProtocolParameters> {
         return this._client.getProtocolParameters();
+    }
+
+    private setupNodeInfoUpdater() {
+        cron.schedule(NODE_INFO_UPDATE_INTERVAL, async () => {
+            await this.updateNodeInfo();
+        });
+    }
+
+    private async updateNodeInfo(): Promise<void> {
+        logger.debug("[NovaNodeInfoService] Updating node info...");
+        const apiClient = ServiceFactory.get<Client>(`client-${this._network.network}`);
+
+        if (apiClient) {
+            try {
+                const response = await apiClient.getNodeInfo();
+
+                if (response?.info) {
+                    this._nodeInfo = response.info;
+                    logger.verbose("[NovaNodeInfoService] Node info updated successfully");
+                }
+            } catch (err) {
+                throw new NodeInfoError(`Failed to fetch node info for "${this._network.network}" with error:\n${err}`);
+            }
+        } else {
+            logger.warn("[NovaNodeInfoService] Couldn't update node info");
+        }
     }
 }

--- a/api/src/services/nova/nodeInfoService.ts
+++ b/api/src/services/nova/nodeInfoService.ts
@@ -7,7 +7,7 @@ import { ServiceFactory } from "../../factories/serviceFactory";
 import logger from "../../logger";
 import { INetwork } from "../../models/db/INetwork";
 
-// The cron interval value to update the circulating supply every 10 minutes.
+// The cron interval value to update the node info every 10 minutes.
 const NODE_INFO_UPDATE_INTERVAL = "*/10 * * * *";
 
 /**

--- a/api/src/services/nova/nodeInfoService.ts
+++ b/api/src/services/nova/nodeInfoService.ts
@@ -8,7 +8,7 @@ import logger from "../../logger";
 import { INetwork } from "../../models/db/INetwork";
 
 // The cron interval value to update the node info every 10 minutes.
-const NODE_INFO_UPDATE_INTERVAL = "*/10 * * * *";
+const NODE_INFO_UPDATE_INTERVAL = "*/1 * * * *";
 
 /**
  * Class to handle Nova protocol node info.


### PR DESCRIPTION
# Description of change

Closes https://github.com/iotaledger/explorer/issues/1377

Because if node info is refreshed, the `latestSlotIndex` used in `outputManaWithDecay` will be correct

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

