### PR TITLE
fix: Fix slotIndex field access in Expiration unlock condition

### DIFF
--- a/client/src/app/components/nova/OutputView.tsx
+++ b/client/src/app/components/nova/OutputView.tsx
@@ -376,12 +376,14 @@ function getSpecialUnlockConditionContent(
         );
     } else if (unlockCondition.type === UnlockConditionType.Expiration) {
         const expirationUnlockCondition = unlockCondition as ExpirationUnlockCondition;
-        const slotTimeRange = slotIndexToUnixTimeRange ? slotIndexToUnixTimeRange(expirationUnlockCondition.slotIndex) : null;
+        // @ts-expect-error The ACTUAL runtime field is 'slot', not 'slotIndex'. https://github.com/iotaledger/iota-sdk/issues/2217
+        const eucSlot = expirationUnlockCondition.slot;
+        const slotTimeRange = slotIndexToUnixTimeRange ? slotIndexToUnixTimeRange(eucSlot) : null;
         const time = slotTimeRange ? DateHelper.format(DateHelper.milliseconds(slotTimeRange?.from)) : null;
         return (
             <React.Fragment>
                 <span>Expiration Unlock Condition{isExpiredOrTimeLocked ? " (Expired)" : ""}</span> <br />
-                {time ? <span>Time: {time} </span> : <span>Slot: {expirationUnlockCondition.slotIndex}</span>}
+                {time ? <span>Time: {time} </span> : <span>Slot: {eucSlot}</span>}
             </React.Fragment>
         );
     } else if (unlockCondition.type === UnlockConditionType.Timelock) {

--- a/client/src/app/components/nova/UnlockConditionView.tsx
+++ b/client/src/app/components/nova/UnlockConditionView.tsx
@@ -48,19 +48,23 @@ const UnlockConditionView: React.FC<UnlockConditionViewProps> = ({ unlockConditi
                             </div>
                         </React.Fragment>
                     )}
-                    {unlockCondition.type === UnlockConditionType.Timelock && (unlockCondition as TimelockUnlockCondition).slotIndex && (
+                    {/** @ts-expect-error The ACTUAL runtime field is 'slot', not 'slotIndex'. https://github.com/iotaledger/iota-sdk/issues/2217 */}
+                    {unlockCondition.type === UnlockConditionType.Timelock && (unlockCondition as TimelockUnlockCondition).slot && (
                         <React.Fragment>
                             <div className="card--label">Slot index</div>
-                            <div className="card--value row">{(unlockCondition as TimelockUnlockCondition).slotIndex}</div>
+                            {/** @ts-expect-error The ACTUAL runtime field is 'slot', not 'slotIndex'. https://github.com/iotaledger/iota-sdk/issues/2217 */}
+                            <div className="card--value row">{(unlockCondition as TimelockUnlockCondition).slot}</div>
                         </React.Fragment>
                     )}
                     {unlockCondition.type === UnlockConditionType.Expiration && (
                         <React.Fragment>
                             <AddressView address={(unlockCondition as ExpirationUnlockCondition).returnAddress} />
-                            {(unlockCondition as ExpirationUnlockCondition).slotIndex && (
+                            {/** @ts-expect-error The ACTUAL runtime field is 'slot', not 'slotIndex'. https://github.com/iotaledger/iota-sdk/issues/2217 */}
+                            {(unlockCondition as ExpirationUnlockCondition).slot && (
                                 <React.Fragment>
                                     <div className="card--label">Slot index</div>
-                                    <div className="card--value row">{(unlockCondition as ExpirationUnlockCondition).slotIndex}</div>
+                                    {/** @ts-expect-error The ACTUAL runtime field is 'slot', not 'slotIndex'. https://github.com/iotaledger/iota-sdk/issues/2217 */}
+                                    <div className="card--value row">{(unlockCondition as ExpirationUnlockCondition).slot}</div>
                                 </React.Fragment>
                             )}
                         </React.Fragment>


### PR DESCRIPTION
# Description of change

Closes https://github.com/iotaledger/explorer/issues/1379

ts-ignore commets can be removed after https://github.com/iotaledger/iota-sdk/issues/2217 is fixed

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

