### PR TITLE
Fix: Expired Assets on Address Page

### DIFF
--- a/api/src/models/api/stardust/IAssociationsResponse.ts
+++ b/api/src/models/api/stardust/IAssociationsResponse.ts
@@ -2,6 +2,7 @@ import { IResponse } from "../IResponse";
 
 export enum AssociationType {
     BASIC_ADDRESS,
+    BASIC_ADDRESS_EXPIRED,
     BASIC_SENDER,
     BASIC_EXPIRATION_RETURN,
     BASIC_STORAGE_RETURN,
@@ -12,6 +13,7 @@ export enum AssociationType {
     ALIAS_ID,
     FOUNDRY_ALIAS,
     NFT_ADDRESS,
+    NFT_ADDRESS_EXPIRED,
     NFT_STORAGE_RETURN,
     NFT_EXPIRATION_RETURN,
     NFT_ISSUER,

--- a/api/src/routes/stardust/output/associated/post.ts
+++ b/api/src/routes/stardust/output/associated/post.ts
@@ -1,7 +1,7 @@
 import { ServiceFactory } from "../../../../factories/serviceFactory";
 import { IAssociationsRequest } from "../../../../models/api/stardust/IAssociationsRequest";
 import { IAssociationsRequestBody } from "../../../../models/api/stardust/IAssociationsRequestBody";
-import { IAssociation, IAssociationsResponse } from "../../../../models/api/stardust/IAssociationsResponse";
+import { AssociationType, IAssociation, IAssociationsResponse } from "../../../../models/api/stardust/IAssociationsResponse";
 import { IConfiguration } from "../../../../models/configuration/IConfiguration";
 import { STARDUST } from "../../../../models/db/protocolVersion";
 import { NetworkService } from "../../../../services/networkService";
@@ -34,12 +34,24 @@ export async function post(
     const helper = new AssociatedOutputsHelper(networkConfig, body.addressDetails);
     await helper.fetch();
     const result = helper.associationToOutputIds;
-
     const associations: IAssociation[] = [];
     for (const [type, outputIds] of result.entries()) {
-        associations.push({ type, outputIds: outputIds.reverse() });
+        if (type !== AssociationType.BASIC_ADDRESS_EXPIRED && type !== AssociationType.NFT_ADDRESS_EXPIRED) {
+            // remove expired basic outputs from basic address associations if they exist
+            if (type === AssociationType.BASIC_ADDRESS && result.get(AssociationType.BASIC_ADDRESS_EXPIRED)?.length > 0) {
+                const expiredIds = result.get(AssociationType.BASIC_ADDRESS_EXPIRED);
+                const filteredOutputIds = outputIds.filter((id) => !expiredIds?.includes(id));
+                associations.push({ type, outputIds: filteredOutputIds.reverse() });
+            } else if (type === AssociationType.NFT_ADDRESS && result.get(AssociationType.NFT_ADDRESS_EXPIRED)?.length > 0) {
+                // remove expired nft outputs from nft address associations if they exist
+                const expiredIds = result.get(AssociationType.NFT_ADDRESS_EXPIRED);
+                const filteredOutputIds = outputIds.filter((id) => !expiredIds?.includes(id));
+                associations.push({ type, outputIds: filteredOutputIds.reverse() });
+            } else {
+                associations.push({ type, outputIds: outputIds.reverse() });
+            }
+        }
     }
-
     return {
         associations,
     };

--- a/api/src/routes/stardust/output/associated/post.ts
+++ b/api/src/routes/stardust/output/associated/post.ts
@@ -1,7 +1,7 @@
 import { ServiceFactory } from "../../../../factories/serviceFactory";
 import { IAssociationsRequest } from "../../../../models/api/stardust/IAssociationsRequest";
 import { IAssociationsRequestBody } from "../../../../models/api/stardust/IAssociationsRequestBody";
-import { AssociationType, IAssociation, IAssociationsResponse } from "../../../../models/api/stardust/IAssociationsResponse";
+import { IAssociationsResponse } from "../../../../models/api/stardust/IAssociationsResponse";
 import { IConfiguration } from "../../../../models/configuration/IConfiguration";
 import { STARDUST } from "../../../../models/db/protocolVersion";
 import { NetworkService } from "../../../../services/networkService";
@@ -33,25 +33,8 @@ export async function post(
 
     const helper = new AssociatedOutputsHelper(networkConfig, body.addressDetails);
     await helper.fetch();
-    const result = helper.associationToOutputIds;
-    const associations: IAssociation[] = [];
-    for (const [type, outputIds] of result.entries()) {
-        if (type !== AssociationType.BASIC_ADDRESS_EXPIRED && type !== AssociationType.NFT_ADDRESS_EXPIRED) {
-            // remove expired basic outputs from basic address associations if they exist
-            if (type === AssociationType.BASIC_ADDRESS && result.get(AssociationType.BASIC_ADDRESS_EXPIRED)?.length > 0) {
-                const expiredIds = result.get(AssociationType.BASIC_ADDRESS_EXPIRED);
-                const filteredOutputIds = outputIds.filter((id) => !expiredIds?.includes(id));
-                associations.push({ type, outputIds: filteredOutputIds.reverse() });
-            } else if (type === AssociationType.NFT_ADDRESS && result.get(AssociationType.NFT_ADDRESS_EXPIRED)?.length > 0) {
-                // remove expired nft outputs from nft address associations if they exist
-                const expiredIds = result.get(AssociationType.NFT_ADDRESS_EXPIRED);
-                const filteredOutputIds = outputIds.filter((id) => !expiredIds?.includes(id));
-                associations.push({ type, outputIds: filteredOutputIds.reverse() });
-            } else {
-                associations.push({ type, outputIds: outputIds.reverse() });
-            }
-        }
-    }
+    const associations = helper.getAssociations();
+
     return {
         associations,
     };

--- a/api/src/services/stardust/stardustApiService.ts
+++ b/api/src/services/stardust/stardustApiService.ts
@@ -560,7 +560,7 @@ export class StardustApiService {
     }
 
     /**
-     * Get the not claimed ntf output ids for an address (outputs owned by the expirationReturnAddress).
+     * Get the not claimed basic output ids for an address (outputs owned by the expirationReturnAddress).
      * @param expirationReturnAddress The address in bech32 format.
      * @returns The nft output ids.
      */

--- a/api/src/utils/stardust/associatedOutputsHelper.ts
+++ b/api/src/utils/stardust/associatedOutputsHelper.ts
@@ -44,6 +44,15 @@ export class AssociatedOutputsHelper {
         );
 
         promises.push(
+            // Basic output -> owner address expired outputs
+            this.fetchAssociatedOutputIds<QueryParameter[]>(
+                async (query) => client.basicOutputIds(query),
+                [{ address }, { expiresBefore: Math.floor(Date.now() / 1000) }],
+                AssociationType.BASIC_ADDRESS_EXPIRED,
+            ),
+        );
+
+        promises.push(
             // Basic output -> storage return address
             this.fetchAssociatedOutputIds<QueryParameter>(
                 async (query) => client.basicOutputIds([query]),
@@ -143,6 +152,15 @@ export class AssociatedOutputsHelper {
         );
 
         promises.push(
+            // Nft output -> owner address expired outputs
+            this.fetchAssociatedOutputIds<NftQueryParameter[]>(
+                async (query) => client.nftOutputIds(query),
+                [{ address }, { expiresBefore: Math.floor(Date.now() / 1000) }],
+                AssociationType.NFT_ADDRESS_EXPIRED,
+            ),
+        );
+
+        promises.push(
             // Nft output -> storage return address
             this.fetchAssociatedOutputIds<NftQueryParameter>(
                 async (query) => client.nftOutputIds([query]),
@@ -197,7 +215,15 @@ export class AssociatedOutputsHelper {
 
         do {
             try {
-                const response = typeof args === "string" ? await fetch(args) : await fetch({ ...args, cursor });
+                let requestArgs: T = null;
+                if (typeof args === "string") {
+                    requestArgs = args;
+                } else if (Array.isArray(args)) {
+                    requestArgs = cursor ? ([...args, { cursor }] as T) : args;
+                } else {
+                    requestArgs = { ...args, cursor };
+                }
+                const response = await fetch(requestArgs);
 
                 if (typeof response === "string") {
                     const outputIds = associationToOutputIds.get(association);


### PR DESCRIPTION
Remove assets from Address Page if expiration time has passed and show them on the Address page for the `expirationReturnAddress`

closes #594 

# Description of change

Please write a summary of your changes and why you made them. Be sure to reference any related issues by adding `fixes # (issue)`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Native tokens can be tested on shimmer using the address `smr1qqe0adqtuyz2pg4gqf37cu9w0d4znj4dejzz6svw3fhtsmgw08j3g4pgs5a` from the task #594 

Nfts can be tested on Testnet using this output that has expiration unlock condition that has passed: `0xec58cc5a805e979cef0d4e62553957ce43a18c221682d2abf34df91ed0d313e20000`

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
