### PR TITLE
fix: initial loading spinner not centered (for suspense fallback)

### DIFF
--- a/client/src/app/App.scss
+++ b/client/src/app/App.scss
@@ -34,16 +34,3 @@
         }
     }
 }
-
-.fixed-center-page {
-    background: var(--body-background);
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-}

--- a/client/src/app/components/Spinner.scss
+++ b/client/src/app/components/Spinner.scss
@@ -2,6 +2,19 @@
 @import "../../scss/mixins";
 @import "../../scss/variables";
 
+.fixed-center-page {
+    background: var(--body-background);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
 .spinner {
     position: relative;
     top: 20px;


### PR DESCRIPTION
# Description of change

Close https://github.com/iotaledger/explorer/issues/1452

Change position of spinner from top-left corner to center (for Suspense fallback)
It's a small update. We don't need opened issue for that.

Before
![image](https://github.com/iotaledger/explorer/assets/25872497/b5bcbc5c-5781-4e15-82d2-6c2f72d94610)

After
![image](https://github.com/iotaledger/explorer/assets/25872497/befa7f02-6806-4c77-8c83-e2c1e8f8d20b)


## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
