### PR TITLE
fix: WASM MIME type in Nginx config

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -24,6 +24,8 @@ RUN echo 'server {\
     }\
   }' > /etc/nginx/sites-available/default
 
+RUN mv ./nginx/wasm.conf /etc/nginx/conf.d/wasm.conf
+
 # Running required steps to prepare the web app prod build
 RUN npm install
 RUN npm run build

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -24,6 +24,7 @@ RUN echo 'server {\
     }\
   }' > /etc/nginx/sites-available/default
 
+# Set Content-Type so streaming compilation works
 RUN mv ./nginx/wasm.conf /etc/nginx/conf.d/wasm.conf
 
 # Running required steps to prepare the web app prod build

--- a/client/nginx/wasm.conf
+++ b/client/nginx/wasm.conf
@@ -1,0 +1,3 @@
+types {
+    application/wasm wasm;
+}

--- a/client/nginx/wasm.conf
+++ b/client/nginx/wasm.conf
@@ -1,3 +1,4 @@
 types {
+    # Set Content-Type so streaming compilation works
     application/wasm wasm;
 }


### PR DESCRIPTION
# Description of change

This PR adds a config file that will tell Nginx to send `.wasm` files with the `Content-Type` as `application/wasm` instead of `application/octet-stream`. This allows us to use [streaming compilation](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static), which may help performance with page loading. It also resolves this warning:
```
`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:
 TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```
Additionally, when the explorer is proxied through Cloudflare, the application/wasm also lets Cloudflare know that it can compress the WASM. In the case of the SDK WASM, Cloudflare will use Brotli to compress it from 6.3 MB to 1.8 MB, further improving the page load time.

Close https://github.com/iotaledger/explorer/issues/1430

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Verified that SDK WASM loads
- Verified that page loads without errors

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
