### PR TITLE
fix: Remove tx inputs sorting by index

### DIFF
--- a/client/src/helpers/stardust/transactionsHelper.ts
+++ b/client/src/helpers/stardust/transactionsHelper.ts
@@ -178,8 +178,7 @@ export class TransactionsHelper {
             }
 
             sortedOutputs = [...outputs, ...remainderOutputs];
-            this.sortInputsAndOuputsByIndex(sortedOutputs);
-            this.sortInputsAndOuputsByIndex(inputs);
+            this.sortOuputsByIndex(sortedOutputs);
         }
 
         return { inputs, unlocks, outputs: sortedOutputs, unlockAddresses, transferTotal };
@@ -189,7 +188,7 @@ export class TransactionsHelper {
      * Sort inputs and outputs in assending order by index.
      * @param items Inputs or Outputs.
      */
-    public static sortInputsAndOuputsByIndex(items: IInput[] | IOutput[]) {
+    public static sortOuputsByIndex(items: IOutput[]) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         items.sort((a: any, b: any) => {
             const firstIndex: string = a.id ? a.id.slice(-4) : a.outputId.slice(-4);


### PR DESCRIPTION
# Description of change

This [PR](https://github.com/iotaledger/explorer/pull/668) introduces sorting of the INPUTs of a TX payload based on the output (that makes that input on the input side) index, which should not be done because the ordering needs to exactly match the unlocks (sorting on the output side by index is still needed).

* Remove index sorting

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

