### PR TITLE
fix: Prevent omni-search to (sometimes) return wrong results

### DIFF
--- a/api/src/utils/stardust/searchExecutor.ts
+++ b/api/src/utils/stardust/searchExecutor.ts
@@ -53,7 +53,7 @@ export class SearchExecutor {
                     this.apiService
                         .milestoneDetailsById(searchQuery.milestoneId)
                         .then((milestoneDetails) => {
-                            if (milestoneDetails) {
+                            if (milestoneDetails.blockId) {
                                 promisesResult = {
                                     milestone: milestoneDetails,
                                 };
@@ -139,7 +139,7 @@ export class SearchExecutor {
                     this.apiService
                         .aliasDetails(searchQuery.aliasId)
                         .then((aliasOutputs) => {
-                            if (aliasOutputs) {
+                            if (aliasOutputs.aliasDetails) {
                                 promisesResult = {
                                     aliasId: searchQuery.aliasId,
                                     did: searchQuery.did,
@@ -162,7 +162,7 @@ export class SearchExecutor {
                     this.apiService
                         .nftDetails(searchQuery.nftId)
                         .then((nftOutputs) => {
-                            if (nftOutputs) {
+                            if (nftOutputs.nftDetails) {
                                 promisesResult = {
                                     nftId: searchQuery.nftId,
                                 };


### PR DESCRIPTION
# Description of change

"A `{ message: "Alias output not found" }` should not be considered as proof the hash is a relevant aliasId in the search"

Same thing in similar logic in other queries.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


