### PR TITLE
Fix: Fix mana calculation output and address page

### DIFF
--- a/client/src/app/routes/nova/OutputPage.tsx
+++ b/client/src/app/routes/nova/OutputPage.tsx
@@ -11,6 +11,7 @@ import { useNetworkInfoNova } from "~/helpers/nova/networkInfo";
 import { buildManaDetailsForOutput, OutputManaDetails } from "~/helpers/nova/manaUtils";
 import { Converter } from "~/helpers/stardust/convertUtils";
 import { useOutputManaRewards } from "~/helpers/nova/hooks/useOutputManaRewards";
+import { Utils } from "@iota/sdk-wasm-nova/web";
 import "./OutputPage.scss";
 
 interface OutputPageProps {
@@ -54,7 +55,7 @@ const OutputPage: React.FC<RouteComponentProps<OutputPageProps>> = ({
     const { blockId, included, spent } = outputMetadataResponse ?? {};
 
     const transactionId = included?.transactionId ?? null;
-    const createdSlotIndex = (included?.slot as number) ?? null;
+    const createdSlotIndex = transactionId ? Utils.computeSlotIndex(transactionId) : null;
     const spentSlotIndex = (spent?.slot as number) ?? null;
     const isSpent = spentSlotIndex !== null;
     const transactionIdSpent = spent?.transactionId ?? null;

--- a/client/src/helpers/nova/hooks/useAddressBalance.ts
+++ b/client/src/helpers/nova/hooks/useAddressBalance.ts
@@ -1,4 +1,4 @@
-import { AddressType, NftOutput, AccountOutput, AnchorOutput, OutputMetadataResponse } from "@iota/sdk-wasm-nova/web";
+import { AddressType, NftOutput, AccountOutput, AnchorOutput, OutputMetadataResponse, Utils } from "@iota/sdk-wasm-nova/web";
 import { useEffect, useState } from "react";
 import { IManaBalance } from "~/models/api/nova/address/IAddressBalanceResponse";
 import { IAddressDetails } from "~/models/api/nova/IAddressDetails";
@@ -64,7 +64,7 @@ export function useAddressBalance(
 
                         // Output mana
                         const { included, spent } = outputMetadata ?? {};
-                        const createdSlotIndex = (included?.slot as number) ?? null;
+                        const createdSlotIndex = included?.transactionId ? Utils.computeSlotIndex(included.transactionId) : null;
                         const spentSlotIndex = (spent?.slot as number) ?? null;
 
                         if (output && createdSlotIndex !== null && protocolInfo) {


### PR DESCRIPTION
# Description of change

Turns out we shouldn't use the `included?.slot` as the `from` then doing output mana calculation. But instead the `included?.transactionId` to compute the `from` slot index.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
