### PR TITLE
fix: remove lazy `App` import

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,10 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 // needed for features from @iota/sdk which use reflection (decorators)
 import "reflect-metadata";
-import React, { Suspense, lazy } from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Route, RouteComponentProps } from "react-router-dom";
 import { AppRouteProps } from "~app/AppRouteProps";
+import App from "~app/App";
 import { ServiceFactory } from "~factories/serviceFactory";
 import "./index.scss";
 import { CHRYSALIS, LEGACY, STARDUST } from "~models/config/protocolVersion";
@@ -26,9 +27,6 @@ import { StardustFeedClient } from "~services/stardust/stardustFeedClient";
 import { TokenRegistryClient } from "~services/stardust/tokenRegistryClient";
 import "@fontsource/ibm-plex-mono";
 import "@fontsource/material-icons";
-import Spinner from "~app/components/Spinner";
-
-const App = lazy(() => import("~app/App"));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const apiEndpoint = (window as any).env.API_ENDPOINT;
@@ -36,19 +34,11 @@ const apiEndpoint = (window as any).env.API_ENDPOINT;
 const AppInitializer = () => {
     return (
         <BrowserRouter>
-            <Suspense
-                fallback={
-                    <div className={"fixed-center-page"}>
-                        <Spinner />
-                    </div>
-                }
-            >
-                <Route
-                    exact={true}
-                    path="/:network?/:action?/:param1?/:param2?/:param3?/:param4?/:param5?"
-                    component={(props: RouteComponentProps<AppRouteProps>) => <App {...props} />}
-                />
-            </Suspense>
+            <Route
+                exact={true}
+                path="/:network?/:action?/:param1?/:param2?/:param3?/:param4?/:param5?"
+                component={(props: RouteComponentProps<AppRouteProps>) => <App {...props} />}
+            />
         </BrowserRouter>
     );
 };


### PR DESCRIPTION
# Description of change

Fixes #1460

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run the client in preview mode `npm run build && npm run preview` and access with the basic access auth in the url. It will have the same behavior as in the deployed version. Try this with and without the fix.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
